### PR TITLE
perf(docs): cut edge requests per page view from 190 to 48

### DIFF
--- a/apps/docs/app/docs/layout.tsx
+++ b/apps/docs/app/docs/layout.tsx
@@ -17,8 +17,17 @@ export default function Layout({ children }: { children: ReactNode }) {
       tree={source.pageTree}
       {...baseOptions}
       nav={{ ...baseOptions.nav, mode: 'top' }}
-      // The tree is two flat groups already; nothing should render a toggle.
-      sidebar={{ collapsible: false }}
+      /*
+       * The tree is two flat groups already; nothing should render a toggle.
+       *
+       * `prefetch` is off because the tree is ~90 links and every one of them
+       * is in the viewport at once. Left on, opening a single page fires an
+       * RSC request for most of the sidebar — pages the reader never asks
+       * for — and the router keys those by segment, so the same href is
+       * fetched again for each context it renders in. It was two thirds of
+       * the site's request volume.
+       */
+      sidebar={{ collapsible: false, prefetch: false }}
       tabMode="navbar"
     >
       {children}

--- a/apps/docs/components/preview-video.tsx
+++ b/apps/docs/components/preview-video.tsx
@@ -30,6 +30,11 @@ export interface PreviewVideoProps {
  * stop, so there it stays on its poster frame and gets its controls back:
  * still watchable, but only on purpose. That check is why this is a client
  * component while `Preview` is not.
+ *
+ * Nothing is fetched — not the file, not the poster — until the frame comes
+ * within a screen of the viewport. A page like Loader stacks ten of these,
+ * and playing all ten on load downloads ten recordings and animates ten
+ * videos to show the reader one.
  */
 export function PreviewVideo({
   src,
@@ -41,8 +46,28 @@ export function PreviewVideo({
 }: PreviewVideoProps) {
   const video = useRef<HTMLVideoElement>(null);
   const [reduced, setReduced] = useState(false);
+  const [near, setNear] = useState(false);
 
   useEffect(() => {
+    const element = video.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        setNear(true);
+        observer.disconnect();
+      },
+      { rootMargin: '400px' },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!near) return;
+
     const query = window.matchMedia('(prefers-reduced-motion: reduce)');
 
     const apply = () => {
@@ -63,7 +88,7 @@ export function PreviewVideo({
     apply();
     query.addEventListener('change', apply);
     return () => query.removeEventListener('change', apply);
-  }, []);
+  }, [near]);
 
   // A phone recording is far taller than it is wide, and at the image frame's
   // width it would be a page-long block. Cap portrait media to phone width.
@@ -73,15 +98,15 @@ export function PreviewVideo({
     <PreviewFrame caption={caption}>
       <video
         ref={video}
-        src={src}
-        poster={poster}
+        src={near ? src : undefined}
+        poster={near ? poster : undefined}
         width={width}
         height={height}
         aria-label={alt}
         muted
         loop
         playsInline
-        preload="metadata"
+        preload="none"
         controls={reduced}
         className={`mx-auto h-auto w-full rounded-lg ${portrait ? 'max-w-[280px]' : 'max-w-md'}`}
       />

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,8 +1,34 @@
 import { createMDX } from 'fumadocs-mdx/next';
 
+/*
+ * Anything under `public/` is served `max-age=0, must-revalidate` unless it is
+ * told otherwise, so a reader moving through five pages re-requests the logo
+ * and every preview on each one — a 304 costs the same as a hit. A day of
+ * freshness makes that one request per asset per day, and a re-recorded
+ * preview keeps its filename, so a day is also the longest anyone waits to
+ * see a corrected one.
+ */
+const STATIC_CACHE = 'public, max-age=86400';
+
+const cached = (source) => ({
+  source,
+  headers: [{ key: 'Cache-Control', value: STATIC_CACHE }],
+});
+
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  async headers() {
+    return [
+      cached('/previews/:path*'),
+      cached('/diagrams/:path*'),
+      cached('/logo-light.png'),
+      cached('/logo-dark.png'),
+      cached('/logo-glow-light.png'),
+      cached('/logo-glow-dark.png'),
+      cached('/icon-512.png'),
+    ];
+  },
   /*
    * A docs URL follows the folder its page is filed in, so regrouping a
    * component moves it. Anything that has been published — the README, the


### PR DESCRIPTION
## What this changes

Three independent changes to `apps/docs`, all aimed at how many HTTP requests one page view costs:

- the docs sidebar no longer prefetches every page in the tree
- assets under `public/` are cacheable for a day instead of revalidating on every navigation
- a preview recording loads when it nears the viewport rather than on mount

Measured on `/docs/components/loader`, the heaviest page in the docs:

| | Before | After |
| --- | --- | --- |
| **Total requests per page view** | **190** | **48** |
| Sidebar RSC prefetch | 130 | 14 |
| Preview videos | 10 | 1 |
| Preview posters | 10 | 1 |
| `_next/static` (immutable either way) | 26 | 26 |

## Why

panelui.dev is at roughly 750,000 of the 1,000,000 free-tier Vercel Edge Requests, and projects are paused past the limit. That number is not really traffic — at 190 requests per view it is about 4,000 page views.

I loaded the page in a browser and counted where they were going.

**The sidebar prefetch was 130 of the 190.** The tree is one flat list of ~90 links and all of them are in the viewport at once, so Next prefetched an RSC payload for nearly every component page on every page view — pages the reader never opened. The router keys those by segment, so the same href went out four to six times:

```
/docs/components/rating?_rsc=8b89xj6dxrl9oaM5
/docs/components/rating?_rsc=CGn8FDWTIc7llQcE
/docs/components/rating?_rsc=E7p87N41Tt2OajxG    ...six in total
```

`sidebar={{ prefetch: false }}` is the documented option for exactly this case.

**Nothing under `public/` was cacheable.** That is the framework default for the folder, not a misconfiguration:

```
$ curl -I https://panelui.dev/previews/loader.mp4
cache-control: public, max-age=0, must-revalidate
```

`must-revalidate` means the browser asks again on every navigation, and a 304 is billed the same as a 200. With 419 files in `public/previews`, a reader moving through five pages pays for the logo and every preview five times over.

`max-age=86400` rather than `immutable` is deliberate: a re-recorded preview keeps its filename, so a day is the longest anyone waits to see a corrected one.

**Every preview played on mount.** Loader stacks ten of them, so opening it downloaded ten recordings and animated ten videos in order to show the reader one. An observer now holds `src` and `poster` back until the frame is within a screen of the viewport. The `width`/`height` attributes already reserve the box, so nothing shifts as they arrive.

## Type of change

- [x] Internal: refactor, tooling, CI

## How it was tested

Web only — this touches `apps/docs`, so there is nothing to run on a device.

- Counted requests with a headless browser against production, then against `next build && next start` from this branch, on the same URL. That is where both columns above come from.
- Confirmed `Cache-Control: public, max-age=86400` is served for `/previews/*` by the local production build, and that `next build` accepts the header patterns.
- Re-checked the `prefers-reduced-motion` path by hand: the poster and controls still appear, and with `preload="none"` nothing downloads until the reader presses play.

Not ticking the iOS / Android / theme boxes — no library or example-app code is touched, so there is nothing meaningful to run there.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)

The remaining checklist items are about library components — Reanimated, theme tokens, `className`, `accessibilityRole`, the docs generator, `meta.json`/`usage.json`. This PR touches only the docs site, so none of them apply.

## Notes for the reviewer

The three commits are independent and land in order of impact — any one can be dropped without affecting the others. The sidebar one is the change that matters; the other two are small.

Two things left alone deliberately:

- **14 RSC prefetches remain**, for the three navbar links (`/`, `/docs`, `/docs/components/button`). They are still duplicated four to six times because they render in the navbar, the mobile menu and the `lg:hidden` sidebar block. They are destinations readers actually go to, and unpicking the duplication means working around the layout's rendering rather than configuring it — it did not seem worth it for 14 requests.
- **`/api/search` is still a dynamic function**, hit per search and so invisible in a page-load count. Exporting a static search index would take it off the function count entirely — a bigger change, and a separate PR if you want it.

Unrelated and so not included here: `package-lock.json` still records `packages/panelui` at 0.48.0 after the 0.49.0 bump, so `npm install` dirties the tree on a fresh clone. One-line fix whenever it suits.
