### PR TITLE
fix(cli): contain project file paths

### DIFF
--- a/packages/cli/src/config.mjs
+++ b/packages/cli/src/config.mjs
@@ -27,7 +27,7 @@ export function defaultConfig(registry = DEFAULT_REGISTRY) {
 }
 
 export function configPath(cwd) {
-  return path.join(cwd, CONFIG_FILE);
+  return projectPath(cwd, CONFIG_FILE, 'Configuration path');
 }
 
 export function readConfig(cwd) {
@@ -61,7 +61,76 @@ export function writeConfig(cwd, config) {
  * following the `@/*` → `./*` mapping Expo's base tsconfig already sets up.
  */
 export function aliasToDir(alias) {
-  return alias.replace(/^@\//, '').replace(/^~\//, '').replace(/^\.\//, '');
+  if (typeof alias !== 'string') {
+    fail('Alias paths must be relative directories.');
+  }
+
+  const directory = alias.replace(/^@\//, '').replace(/^~\//, '').replace(/^\.\//, '');
+  return validateRelativePath(directory, 'Alias path', { allowEmpty: true });
+}
+
+/** Rejects paths that could escape a project on the current platform or Windows. */
+export function validateRelativePath(value, label = 'Path', { allowEmpty = false } = {}) {
+  if (typeof value !== 'string' || value.includes('\0')) {
+    fail(`${label} must be a relative path.`);
+  }
+
+  if (!value && !allowEmpty) {
+    fail(`${label} must not be empty.`);
+  }
+
+  if (
+    path.isAbsolute(value) ||
+    path.win32.isAbsolute(value) ||
+    /^[a-zA-Z]:/.test(value) ||
+    value.split(/[\\/]+/).includes('..')
+  ) {
+    fail(`${label} must stay inside the project.`);
+  }
+
+  return value;
+}
+
+/** Resolve a user or registry path, refusing anything outside the project root. */
+export function projectPath(cwd, relativePath, label = 'Path') {
+  const root = path.resolve(cwd);
+  const destination = path.resolve(root, validateRelativePath(relativePath, label));
+  const relative = path.relative(root, destination);
+
+  if (!relative || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    fail(`${label} must stay inside the project.`);
+  }
+
+  return destination;
+}
+
+/** A scaffold name must produce exactly one child directory, on every platform. */
+export function validateProjectName(name) {
+  if (
+    typeof name !== 'string' ||
+    !name.trim() ||
+    name === '.' ||
+    name === '..' ||
+    name.includes('\0') ||
+    /[\\/]/.test(name) ||
+    path.isAbsolute(name) ||
+    path.win32.isAbsolute(name) ||
+    /^[a-zA-Z]:/.test(name)
+  ) {
+    fail('Project name must be a single directory name inside the current folder.');
+  }
+
+  return name;
+}
+
+/** Validate every configured path before it reaches a filesystem write boundary. */
+export function validateConfigPaths(config) {
+  const aliases = { ...CANONICAL_ALIASES, ...(config.aliases ?? {}) };
+  aliasToDir(aliases.components);
+  aliasToDir(aliases.lib);
+  aliasToDir(aliases.hooks);
+  validateRelativePath(config.css ?? 'global.css', 'CSS path');
+  validateRelativePath(config.theme ?? 'theme.css', 'Theme path');
 }
 
 /**
@@ -69,18 +138,23 @@ export function aliasToDir(alias) {
  * are `ui/…`, `lib/…`, `hooks/…` or a bare `theme.css`.
  */
 export function targetPath(cwd, config, registryPath) {
+  const safeRegistryPath = validateRelativePath(registryPath, 'Registry file path');
+  if (safeRegistryPath.includes('\\')) {
+    fail('Registry file paths must use forward slashes.');
+  }
+
   const aliases = { ...CANONICAL_ALIASES, ...(config.aliases ?? {}) };
-  const [group, ...rest] = registryPath.split('/');
+  const [group, ...rest] = safeRegistryPath.split('/');
 
   if (rest.length === 0) {
     // theme.css and anything else at the root goes where the config says.
-    return path.join(cwd, config.theme ?? registryPath);
+    return projectPath(cwd, config.theme ?? safeRegistryPath, 'Theme path');
   }
 
   const alias =
     group === 'ui' ? aliases.components : group === 'lib' ? aliases.lib : aliases.hooks;
 
-  return path.join(cwd, aliasToDir(alias), ...rest);
+  return projectPath(cwd, path.join(aliasToDir(alias), ...rest), 'Registry file path');
 }
 
 /**

--- a/packages/cli/src/init.mjs
+++ b/packages/cli/src/init.mjs
@@ -13,6 +13,9 @@ import {
   aliasToDir,
   defaultConfig,
   detectProject,
+  projectPath as resolveProjectPath,
+  validateConfigPaths,
+  validateProjectName,
   readConfig,
   writeConfig,
 } from './config.mjs';
@@ -94,6 +97,8 @@ export async function init(options) {
     config.css = await ask('Which file is your CSS entry?', config.css);
   }
 
+  validateConfigPaths(config);
+
   step(`Write ${CONFIG_FILE}`);
   if (!options.dryRun) {
     writeConfig(cwd, config);
@@ -103,7 +108,7 @@ export async function init(options) {
   // The tokens are global rather than per component — every class name in the
   // library resolves through them — so they come in whole, once.
   const theme = await fetchItem(config.registry, 'theme');
-  const themePath = path.join(cwd, config.theme);
+  const themePath = resolveProjectPath(cwd, config.theme, 'Theme path');
   const themeExists = fs.existsSync(themePath);
 
   if (themeExists && !options.overwrite) {
@@ -149,11 +154,12 @@ export async function create(options) {
       ))
     : await select('Which template?', TEMPLATES, { assumeYes: options.yes });
 
-  const projectName =
+  const projectName = validateProjectName(
     options.name ??
-    (options.yes
-      ? template.defaultProjectName
-      : await ask('What is it called?', template.defaultProjectName));
+      (options.yes
+        ? template.defaultProjectName
+        : await ask('What is it called?', template.defaultProjectName))
+  );
 
   const theme = options.theme
     ? (THEMES.find((entry) => entry.id === options.theme) ??
@@ -177,7 +183,7 @@ export async function create(options) {
     { assumeYes: options.yes }
   );
 
-  const projectPath = path.join(cwd, projectName);
+  const projectPath = resolveProjectPath(cwd, projectName, 'Project name');
   if (fs.existsSync(projectPath) && fs.readdirSync(projectPath).length > 0) {
     fail(`${projectName}/ already exists and is not empty.`, 'Pick another name.');
   }
@@ -197,6 +203,7 @@ export async function create(options) {
   // The config the `add` command reads. A generated project already has the
   // directories it names, so nothing here is a question.
   const config = defaultConfig(options.registry ?? DEFAULT_REGISTRY);
+  validateConfigPaths(config);
   writeConfig(projectPath, config);
   success(`Wrote ${CONFIG_FILE}`);
 

--- a/packages/cli/src/patch.mjs
+++ b/packages/cli/src/patch.mjs
@@ -7,7 +7,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { aliasToDir } from './config.mjs';
+import { aliasToDir, projectPath, validateConfigPaths } from './config.mjs';
 import { confirm, dim, printAddition, step, success, warn } from './ui.mjs';
 
 /**
@@ -19,7 +19,8 @@ import { confirm, dim, printAddition, step, success, warn } from './ui.mjs';
  * miserable thing to debug.
  */
 export async function patchCss(cwd, config, { assumeYes, dryRun }) {
-  const cssPath = path.join(cwd, config.css ?? 'global.css');
+  validateConfigPaths(config);
+  const cssPath = projectPath(cwd, config.css ?? 'global.css', 'CSS path');
   const exists = fs.existsSync(cssPath);
   const current = exists ? fs.readFileSync(cssPath, 'utf8') : '';
 

--- a/packages/cli/test/path-containment.test.mjs
+++ b/packages/cli/test/path-containment.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  defaultConfig,
+  targetPath,
+  validateConfigPaths,
+  validateProjectName,
+} from '../src/config.mjs';
+import { create } from '../src/init.mjs';
+import { CliError } from '../src/ui.mjs';
+
+function temporaryProject() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-cli-path-'));
+}
+
+test('keeps valid registry destinations inside the project', () => {
+  const cwd = temporaryProject();
+  const config = {
+    ...defaultConfig(),
+    aliases: { components: '@/src/components', lib: '~/src/lib', hooks: './src/hooks' },
+    css: 'src/global.css',
+    theme: 'src/theme.css',
+  };
+
+  try {
+    validateConfigPaths(config);
+    assert.equal(
+      targetPath(cwd, config, 'ui/button.tsx'),
+      path.join(cwd, 'src/components/button.tsx')
+    );
+    assert.equal(targetPath(cwd, config, 'theme.css'), path.join(cwd, 'src/theme.css'));
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('rejects registry and configured paths that can escape a project', () => {
+  const cwd = temporaryProject();
+  const config = defaultConfig();
+
+  try {
+    for (const registryPath of [
+      '/tmp/victim.ts',
+      '../victim.ts',
+      'ui/../../victim.ts',
+      'C:\\victim.ts',
+      '\\victim.ts',
+      '\\\\server\\share\\victim.ts',
+    ]) {
+      assert.throws(() => targetPath(cwd, config, registryPath), CliError);
+    }
+
+    assert.throws(
+      () => validateConfigPaths({ ...config, aliases: { components: '@/../../victim' } }),
+      CliError
+    );
+    assert.throws(() => validateConfigPaths({ ...config, css: '..\\victim.css' }), CliError);
+    assert.throws(() => validateConfigPaths({ ...config, theme: 'C:\\victim.css' }), CliError);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('rejects unsafe scaffold names before any project files are created', async () => {
+  const cwd = temporaryProject();
+  const victim = path.resolve(cwd, '..', 'victim');
+
+  try {
+    for (const name of ['../victim', '/victim', 'C:\\victim', '\\victim', '\\\\server\\share']) {
+      await assert.rejects(create({ cwd, name, yes: true }), CliError);
+    }
+
+    assert.equal(validateProjectName('valid-app'), 'valid-app');
+    assert.equal(fs.existsSync(victim), false);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- reject absolute and traversal-based filesystem destinations before the CLI writes files
- validate scaffold names as safe project-directory segments
- add path-containment coverage for POSIX and Windows-shaped inputs

## Verification
- `node --test packages/cli/test/path-containment.test.mjs`
- CLI init dry-runs for malicious and valid project names
- `node --check` on modified CLI modules
- `git diff origin/main...HEAD --check`

## Notes
- No linked issue: PanelUI does not require issue references, and this work is tracked locally as CLI-002.