### PR TITLE
fix(cli): resolve CSS imports from nested entries

### DIFF
--- a/packages/cli/src/patch.mjs
+++ b/packages/cli/src/patch.mjs
@@ -23,6 +23,7 @@ export async function patchCss(cwd, config, { assumeYes, dryRun }) {
   const cssPath = projectPath(cwd, config.css ?? 'global.css', 'CSS path');
   const exists = fs.existsSync(cssPath);
   const current = exists ? fs.readFileSync(cssPath, 'utf8') : '';
+  const cssDir = path.dirname(cssPath);
 
   const sourceDirs = [
     ...new Set(
@@ -30,19 +31,27 @@ export async function patchCss(cwd, config, { assumeYes, dryRun }) {
         .map(aliasToDir)
         // Scan the top-level directory rather than the leaf, so a later
         // `add` that creates a sibling folder is covered without re-running.
-        .map((dir) => `./${dir.split('/')[0]}`)
+        .map((dir) => dir.split(/[\\/]/)[0])
     ),
   ];
 
+  const legacyWanted = [
+    `@import './${config.theme ?? 'theme.css'}';`,
+    ...sourceDirs.map((dir) => `@source './${dir}';`),
+  ];
   const wanted = [
     `@import 'tailwindcss';`,
     `@import 'uniwind';`,
-    `@import './${config.theme ?? 'theme.css'}';`,
-    ...sourceDirs.map((dir) => `@source '${dir}';`),
+    `@import '${relativeCssSpecifier(cssDir, path.join(cwd, config.theme ?? 'theme.css'))}';`,
+    ...sourceDirs.map((dir) => `@source '${relativeCssSpecifier(cssDir, path.join(cwd, dir))}';`),
   ];
 
-  const missing = wanted.filter((line) => !current.includes(line.replace(/;$/, '')));
-  if (!missing.length) {
+  const corrected = legacyWanted.reduce(
+    (css, legacy, index) => css.replaceAll(legacy, wanted[index + 2]),
+    current
+  );
+  const missing = wanted.filter((line) => !corrected.includes(line.replace(/;$/, '')));
+  if (!missing.length && corrected === current) {
     success(`${path.basename(cssPath)} already set up`);
     return;
   }
@@ -56,10 +65,20 @@ export async function patchCss(cwd, config, { assumeYes, dryRun }) {
     return;
   }
 
-  const next = exists ? `${missing.join('\n')}\n\n${current}` : `${missing.join('\n')}\n`;
+  const next = exists
+    ? missing.length
+      ? `${missing.join('\n')}\n\n${corrected}`
+      : corrected
+    : `${missing.join('\n')}\n`;
   fs.mkdirSync(path.dirname(cssPath), { recursive: true });
   fs.writeFileSync(cssPath, next);
   success(`Wrote ${path.relative(cwd, cssPath)}`);
+}
+
+/** Convert a filesystem-relative target into a portable CSS module specifier. */
+function relativeCssSpecifier(fromDir, targetPath) {
+  const relative = path.relative(fromDir, targetPath).split(path.sep).join('/');
+  return relative.startsWith('.') ? relative : `./${relative}`;
 }
 
 const METRO_TEMPLATE = `const { getDefaultConfig } = require('expo/metro-config');

--- a/packages/cli/test/patch-css.test.mjs
+++ b/packages/cli/test/patch-css.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { patchCss } from '../src/patch.mjs';
+
+async function withProject(run) {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-cli-css-'));
+  try {
+    await run(cwd);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+const config = (css) => ({
+  css,
+  theme: 'theme.css',
+  aliases: {
+    components: '@/components/ui',
+    lib: '@/lib',
+    hooks: '@/hooks',
+  },
+});
+
+test('patchCss preserves root CSS import and source paths', async () => {
+  await withProject(async (cwd) => {
+    await patchCss(cwd, config('global.css'), { assumeYes: true, dryRun: false });
+
+    assert.equal(
+      fs.readFileSync(path.join(cwd, 'global.css'), 'utf8'),
+      [
+        "@import 'tailwindcss';",
+        "@import 'uniwind';",
+        "@import './theme.css';",
+        "@source './components';",
+        "@source './lib';",
+        "@source './hooks';",
+        '',
+      ].join('\n')
+    );
+  });
+});
+
+test('patchCss generates portable paths from a nested CSS entry', async () => {
+  await withProject(async (cwd) => {
+    const cssPath = path.join(cwd, 'app/styles/global.css');
+    fs.mkdirSync(path.dirname(cssPath), { recursive: true });
+    fs.writeFileSync(
+      cssPath,
+      [
+        "@import 'tailwindcss';",
+        "@import 'uniwind';",
+        "@import './theme.css';",
+        "@source './components';",
+        "@source './lib';",
+        "@source './hooks';",
+        '',
+      ].join('\n')
+    );
+
+    await patchCss(cwd, config('app/styles/global.css'), { assumeYes: true, dryRun: false });
+
+    const css = fs.readFileSync(cssPath, 'utf8');
+    assert.match(css, /@import '\.\.\/\.\.\/theme\.css';/);
+    assert.match(css, /@source '\.\.\/\.\.\/components';/);
+    assert.match(css, /@source '\.\.\/\.\.\/lib';/);
+    assert.match(css, /@source '\.\.\/\.\.\/hooks';/);
+    assert.ok(!css.includes('\\'));
+  });
+});
+
+test('patchCss generates relative paths for a new nested CSS entry', async () => {
+  await withProject(async (cwd) => {
+    await patchCss(cwd, config('app/styles/global.css'), { assumeYes: true, dryRun: false });
+
+    assert.equal(
+      fs.readFileSync(path.join(cwd, 'app/styles/global.css'), 'utf8'),
+      [
+        "@import 'tailwindcss';",
+        "@import 'uniwind';",
+        "@import '../../theme.css';",
+        "@source '../../components';",
+        "@source '../../lib';",
+        "@source '../../hooks';",
+        '',
+      ].join('\n')
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- derive CSS `@import` and `@source` specifiers from the CSS entry directory
- preserve existing root-entry output while fixing nested entries
- migrate legacy generated paths and cover both existing and newly created nested CSS files

## Root cause

The CLI emitted fixed `./theme.css`, `./components`, `./lib`, and `./hooks` paths. CSS resolves these from the entry file directory, so a nested entry pointed at nonexistent nested resources.

## Verification

- `node --check packages/cli/src/patch.mjs`
- `node --test packages/cli/test/*.test.mjs` — 10 passed
- `git diff origin/main...HEAD --check`
- root CSS retains `./...` paths; nested `app/styles/global.css` emits `../../...` paths with POSIX separators

## Notes

No linked issue: PanelUI does not require issue references; this work is tracked locally as CLI-003.