### PR TITLE
fix(docs): limit repeated route prefetches

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -274,10 +274,10 @@ export default function HomePage() {
         <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 text-sm text-muted-foreground sm:flex-row">
           <p>MIT © Khalid Abdi</p>
           <nav className="flex gap-6" aria-label="Footer">
-            <Link href="/docs" className="hover:text-foreground">
+            <Link href="/docs" prefetch={false} className="hover:text-foreground">
               Documentation
             </Link>
-            <Link href="/docs/components" className="hover:text-foreground">
+            <Link href="/docs/components" prefetch={false} className="hover:text-foreground">
               Components
             </Link>
             <Link href={site.npm} className="hover:text-foreground">

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -5,6 +5,7 @@ import { Geist_Mono, Inter } from 'next/font/google';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import { Analytics } from '@vercel/analytics/next';
 import { GoogleAnalytics } from '@/components/google-analytics';
+import { LayoutLink } from '@/components/layout-link';
 import { OpenPanel } from '@/components/openpanel';
 import { WebMcp } from '@/components/web-mcp';
 import { absoluteUrl, site } from '@/lib/site';
@@ -105,7 +106,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     >
       {/* `isolate` keeps Base UI portals layering against this root. */}
       <body className="isolate flex min-h-screen flex-col font-sans antialiased">
-        <RootProvider>{children}</RootProvider>
+        <RootProvider components={{ Link: LayoutLink }}>{children}</RootProvider>
         {/*
           All three mount once here, because the root layout wraps every page
           and nothing else should mount any of them again.

--- a/apps/docs/components/layout-link.tsx
+++ b/apps/docs/components/layout-link.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import Link from 'next/link';
+import type { ComponentPropsWithRef } from 'react';
+
+/**
+ * Routes repeated by the persistent Fumadocs chrome.
+ *
+ * The desktop navbar, mobile menu and CTA can all contain the same destination,
+ * so viewport prefetching each copy spends several RSC requests on one route.
+ * Content links use `next/link` directly and keep its normal prefetching; this
+ * policy applies only to links Fumadocs creates for its shared layouts.
+ */
+const REPEATED_CHROME_ROUTES = new Set(['/', '/docs', '/docs/components']);
+
+type LayoutLinkProps = ComponentPropsWithRef<'a'> & { prefetch?: boolean };
+
+export function LayoutLink({ href = '#', prefetch, ...props }: LayoutLinkProps) {
+  const repeated = REPEATED_CHROME_ROUTES.has(href);
+
+  return <Link href={href} prefetch={prefetch ?? (repeated ? false : null)} {...props} />;
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "postinstall": "fumadocs-mdx",
     "typecheck": "tsc --noEmit",
-    "test": "node --test test/*.test.mjs",
+    "test": "node --experimental-strip-types --test test/*.test.mjs",
     "docs:generate": "node scripts/extract.mjs && node scripts/gen.mjs && node scripts/extract-icons.mjs && node scripts/build-registry.mjs && node scripts/build-skill.mjs && node scripts/build-skill-assets.mjs",
     "registry:build": "node scripts/build-registry.mjs",
     "prebuild": "node scripts/extract-icons.mjs && node scripts/build-registry.mjs && node scripts/build-skill.mjs && node scripts/build-skill-assets.mjs"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "postinstall": "fumadocs-mdx",
     "typecheck": "tsc --noEmit",
+    "test": "node --test test/*.test.mjs",
     "docs:generate": "node scripts/extract.mjs && node scripts/gen.mjs && node scripts/extract-icons.mjs && node scripts/build-registry.mjs && node scripts/build-skill.mjs && node scripts/build-skill-assets.mjs",
     "registry:build": "node scripts/build-registry.mjs",
     "prebuild": "node scripts/extract-icons.mjs && node scripts/build-registry.mjs && node scripts/build-skill.mjs && node scripts/build-skill-assets.mjs"

--- a/apps/docs/test/prefetch-policy.test.mjs
+++ b/apps/docs/test/prefetch-policy.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const docs = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (file) => fs.readFileSync(path.join(docs, file), 'utf8');
+
+test('persistent layout chrome does not prefetch its repeated destinations', () => {
+  const layoutLink = read('components/layout-link.tsx');
+  const rootLayout = read('app/layout.tsx');
+
+  assert.match(
+    layoutLink,
+    /REPEATED_CHROME_ROUTES = new Set\(\['\/', '\/docs', '\/docs\/components'\]\)/
+  );
+  assert.match(layoutLink, /repeated \? false : null/);
+  assert.match(rootLayout, /<RootProvider components=\{\{ Link: LayoutLink \}\}>/);
+});
+
+test('footer copies opt out while primary content navigation keeps prefetching', () => {
+  const home = read('app/(home)/page.tsx');
+  const showcase = read('components/showcase/index.tsx');
+
+  assert.match(home, /href="\/docs" prefetch=\{false\} className="hover:text-foreground"/);
+  assert.match(
+    home,
+    /href="\/docs\/components" prefetch=\{false\} className="hover:text-foreground"/
+  );
+  assert.match(home, /<Button render=\{<Link href="\/docs" \/>\}>/);
+  assert.match(showcase, /render=\{<Link href="\/docs\/components" \/>\}/);
+});


### PR DESCRIPTION
## Summary
- inject a custom Fumadocs Link policy through `RootProvider`
- disable prefetch for persistent chrome links repeated across desktop/mobile/CTA contexts
- disable duplicate footer prefetches for the same docs destinations
- preserve normal prefetching for intentional hero and showcase navigation
- add focused source-contract tests for the policy boundary

## Why
Persistent navigation renders the same destinations in multiple layout contexts, and each default-prefetched copy can issue redundant RSC requests. The sidebar already opts out; this closes the remaining repeated navbar/menu/CTA/footer surface without globally disabling useful content-link prefetching.

## Validation
- `npm ci --ignore-scripts`
- `npm run postinstall --workspace=docs && npm run typecheck --workspace=docs`
- `npm test --workspace=docs`: 2 passed
- `npm run build --workspace=docs` (295 static pages)
- `git diff --check`

## Scope
No production browser trace was captured for this patch, so the evidence is the supported Fumadocs custom-Link seam, explicit Next Link prefetch controls, focused source contracts, and the production build. The repeated-route set remains intentionally small so content navigation keeps its normal behavior.