### PR TITLE
fix(cli): reject flags without values

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -60,6 +60,8 @@ npx panelui-cli@latest list
 | `--cwd <dir>` | Run against another directory |
 | `--registry <url>` | Use a different registry |
 
+A value-taking flag without its value prints its usage and exits with status 1. No command runs.
+
 ## `panelui.json`
 
 ```json

--- a/packages/cli/bin/panelui.mjs
+++ b/packages/cli/bin/panelui.mjs
@@ -9,7 +9,7 @@ import process from 'node:process';
 import { add, list } from '../src/add.mjs';
 import { init } from '../src/init.mjs';
 import { mcp, mcpInit } from '../src/mcp.mjs';
-import { CliError, bold, dim, error, info } from '../src/ui.mjs';
+import { CliError, bold, dim, error, info, optionValue } from '../src/ui.mjs';
 
 const HELP = `
 ${bold('panelui-cli')} — components for Expo, copied into your project.
@@ -86,20 +86,25 @@ function parseArgs(argv) {
         options.version = true;
         break;
       case '--cwd':
-        options.cwd = argv[++i];
+        options.cwd = optionValue(argv, i, arg, '<dir>');
+        i += 1;
         break;
       case '--registry':
         // A trailing slash would produce `…/r//item.json`.
-        options.registry = argv[++i]?.replace(/\/+$/, '');
+        options.registry = optionValue(argv, i, arg, '<url>').replace(/\/+$/, '');
+        i += 1;
         break;
       case '--template':
-        options.template = argv[++i];
+        options.template = optionValue(argv, i, arg, '<name>');
+        i += 1;
         break;
       case '--name':
-        options.name = argv[++i];
+        options.name = optionValue(argv, i, arg, '<name>');
+        i += 1;
         break;
       case '--theme':
-        options.theme = argv[++i];
+        options.theme = optionValue(argv, i, arg, '<name>');
+        i += 1;
         break;
       default:
         if (arg.startsWith('-')) {

--- a/packages/cli/src/ui.mjs
+++ b/packages/cli/src/ui.mjs
@@ -41,6 +41,15 @@ export function error(message) {
 /** A fatal, expected failure — a message, not a stack trace. */
 export class CliError extends Error {}
 
+/** Reads the next argv entry for a flag that cannot stand on its own. */
+export function optionValue(argv, index, flag, placeholder) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('-')) {
+    fail(`Missing value for ${flag}.`, `Usage: ${flag} ${placeholder}`);
+  }
+  return value;
+}
+
 export function fail(message, hint) {
   const err = new CliError(message);
   err.hint = hint;

--- a/packages/cli/test/flag-arity.test.mjs
+++ b/packages/cli/test/flag-arity.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { test } from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const executables = [
+  {
+    name: 'panelui-cli',
+    file: path.resolve(here, '../bin/panelui.mjs'),
+    flags: [
+      ['--cwd', '<dir>'],
+      ['--registry', '<url>'],
+      ['--template', '<name>'],
+      ['--name', '<name>'],
+      ['--theme', '<name>'],
+    ],
+  },
+  {
+    name: 'create-panelui-app',
+    file: path.resolve(here, '../../create-panelui-app/index.mjs'),
+    flags: [
+      ['--template', '<name>'],
+      ['--theme', '<name>'],
+      ['--name', '<name>'],
+    ],
+  },
+];
+
+for (const executable of executables) {
+  test(`${executable.name} rejects value flags at the end of argv`, () => {
+    for (const [flag, placeholder] of executable.flags) {
+      const result = spawnSync(process.execPath, [executable.file, flag], {
+        encoding: 'utf8',
+        env: { ...process.env, NO_COLOR: '1' },
+      });
+      const output = `${result.stdout}${result.stderr}`;
+
+      assert.equal(result.status, 1, `${executable.name} ${flag}`);
+      assert.match(output, new RegExp(`Missing value for ${flag}\\.`));
+      assert.match(output, new RegExp(`Usage: ${flag} ${placeholder.replace(/[<>]/g, '\\$&')}`));
+      assert.doesNotMatch(output, /Unexpected error:/);
+    }
+  });
+
+  test(`${executable.name} does not consume another flag as a value`, () => {
+    const [flag, placeholder] = executable.flags[0];
+    const result = spawnSync(process.execPath, [executable.file, flag, '--help'], {
+      encoding: 'utf8',
+      env: { ...process.env, NO_COLOR: '1' },
+    });
+    const output = `${result.stdout}${result.stderr}`;
+
+    assert.equal(result.status, 1);
+    assert.match(output, new RegExp(`Usage: ${flag} ${placeholder.replace(/[<>]/g, '\\$&')}`));
+  });
+}

--- a/packages/create-panelui-app/README.md
+++ b/packages/create-panelui-app/README.md
@@ -28,9 +28,12 @@ npx create-panelui-app@latest my-app --template starter --theme moon --yes
 | --- | --- | --- |
 | `--template <name>` | `starter`, `minimal` | `starter` gives you tabs, a themed dashboard, a component gallery and a theme picker; `minimal` is one screen, everything wired, nothing to delete. |
 | `--theme <name>` | `panel`, `moon`, `grass` | Which token set the app is themed with. Change it later in `global.css`. |
+| `--name <name>` | Project folder name | The same value accepted as the bare first argument. |
 | `--yes`, `-y` | | Accept every prompt and use the defaults. |
 | `--help`, `-h` | | Print the usage. |
 | `--version`, `-v` | | Print the version. |
+
+A value-taking option without its value prints its usage and exits with status 1. No project is created.
 
 ## What it is
 

--- a/packages/create-panelui-app/index.mjs
+++ b/packages/create-panelui-app/index.mjs
@@ -17,7 +17,7 @@
  */
 import process from 'node:process';
 import { create } from 'panelui-cli/init';
-import { CliError, bold, dim, error, info } from 'panelui-cli/ui';
+import { CliError, bold, dim, error, info, optionValue } from 'panelui-cli/ui';
 
 const HELP = `
 ${bold('create-panelui-app')} — a new Expo app, with PanelUI already set up.
@@ -58,13 +58,16 @@ function parseArgs(argv) {
         version = true;
         break;
       case '--template':
-        options.template = argv[++i];
+        options.template = optionValue(argv, i, arg, '<name>');
+        i += 1;
         break;
       case '--theme':
-        options.theme = argv[++i];
+        options.theme = optionValue(argv, i, arg, '<name>');
+        i += 1;
         break;
       case '--name':
-        options.name = argv[++i];
+        options.name = optionValue(argv, i, arg, '<name>');
+        i += 1;
         break;
       default:
         if (arg.startsWith('-')) throw new CliError(`Unknown option: ${arg}`);


### PR DESCRIPTION
## Summary
- validate every value-taking flag in both shipped executables
- reject end-of-argv and following-option cases before commands run
- share one option-value validator through the CLI package export
- document the status-1 usage contract and the existing create-app --name option
- add command-level coverage for all eight flag/executable combinations

## Why
A value flag at the end of argv was dereferenced without validation, producing an internal TypeError. A following flag could also be consumed as the missing value.

## Behavior
- prints Missing value for <flag>. and the exact flag usage
- exits with status 1
- does not run the command or create a project
- does not consume a following option token

## Validation
- node --test packages/cli/test/*.test.mjs: 11 passed
- node --check for both executables and ui.mjs
- npm run typecheck --workspaces --if-present
- npm pack --dry-run for panelui-cli and create-panelui-app
- git diff --check