### PR TITLE
fix(cli): honor assume-yes across prompts

### DIFF
--- a/packages/cli/bin/panelui.mjs
+++ b/packages/cli/bin/panelui.mjs
@@ -51,7 +51,7 @@ ${bold('Examples')}
 function parseArgs(argv) {
   const options = {
     cwd: process.cwd(),
-    yes: false,
+    assumeYes: false,
     overwrite: false,
     dryRun: false,
     registry: undefined,
@@ -69,7 +69,7 @@ function parseArgs(argv) {
     switch (arg) {
       case '--yes':
       case '-y':
-        options.yes = true;
+        options.assumeYes = true;
         break;
       case '--overwrite':
         options.overwrite = true;

--- a/packages/cli/src/add.mjs
+++ b/packages/cli/src/add.mjs
@@ -76,7 +76,7 @@ export async function add(names, options) {
     return;
   }
 
-  if (!(await confirm(`Write ${pending.length} file${pending.length === 1 ? '' : 's'}?`, { assumeYes: options.yes }))) {
+  if (!(await confirm(`Write ${pending.length} file${pending.length === 1 ? '' : 's'}?`, options))) {
     info(dim('Cancelled.'));
     return;
   }

--- a/packages/cli/src/init.mjs
+++ b/packages/cli/src/init.mjs
@@ -72,13 +72,13 @@ export async function init(options) {
 
   if (!project.isExpo) {
     warn('This does not look like an Expo project — no `expo` dependency found.');
-    if (!(await confirm('Continue anyway?', { defaultValue: false, assumeYes: options.yes }))) {
+    if (!(await confirm('Continue anyway?', { ...options, defaultValue: false }))) {
       return;
     }
   }
 
   const existing = readConfig(cwd);
-  if (existing && !options.yes) {
+  if (existing && !options.assumeYes) {
     const overwrite = await confirm(`${CONFIG_FILE} already exists. Reconfigure?`, {
       defaultValue: false,
     });
@@ -90,7 +90,7 @@ export async function init(options) {
 
   const config = defaultConfig(options.registry ?? DEFAULT_REGISTRY);
 
-  if (!options.yes && process.stdin.isTTY) {
+  if (!options.assumeYes && process.stdin.isTTY) {
     config.aliases.components = await ask('Where should components go?', config.aliases.components);
     config.aliases.lib = await ask('Where should utilities go?', config.aliases.lib);
     config.aliases.hooks = await ask('Where should hooks go?', config.aliases.hooks);
@@ -152,11 +152,11 @@ export async function create(options) {
         `No template called "${options.template}".`,
         `Try: ${TEMPLATES.map((entry) => entry.name).join(', ')}`
       ))
-    : await select('Which template?', TEMPLATES, { assumeYes: options.yes });
+    : await select('Which template?', TEMPLATES, options);
 
   const projectName = validateProjectName(
     options.name ??
-      (options.yes
+      (options.assumeYes
         ? template.defaultProjectName
         : await ask('What is it called?', template.defaultProjectName))
   );
@@ -170,7 +170,7 @@ export async function create(options) {
     : await select(
         'Which theme?',
         THEMES.map((entry) => ({ ...entry, title: entry.name })),
-        { assumeYes: options.yes }
+        options
       );
 
   const mode = await select(
@@ -180,7 +180,7 @@ export async function create(options) {
       { title: 'Light', id: 'light' },
       { title: 'Dark', id: 'dark' },
     ],
-    { assumeYes: options.yes }
+    options
   );
 
   const projectPath = resolveProjectPath(cwd, projectName, 'Project name');

--- a/packages/cli/src/patch.mjs
+++ b/packages/cli/src/patch.mjs
@@ -203,6 +203,27 @@ export function detectPackageManager(cwd) {
 }
 
 /**
+ * A package name, optionally scoped, optionally pinned to a version.
+ *
+ * Names arrive from registry JSON, and on Windows the installer has to be
+ * reached through a shell because `npm` and friends are `.cmd` shims there.
+ * Anything a shell would read as syntax — a space, `&`, `|`, a quote — is
+ * therefore not a package name this will pass on, whatever the registry says.
+ */
+const PACKAGE_SPEC = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*(?:@[a-zA-Z0-9][a-zA-Z0-9.^~*+-]*)?$/;
+
+/** Refuse to hand the installer anything that is not plainly a package. */
+function assertInstallable(packages) {
+  const rejected = packages.filter((name) => typeof name !== 'string' || !PACKAGE_SPEC.test(name));
+  if (rejected.length) {
+    fail(
+      `Refusing to install ${rejected.map((name) => JSON.stringify(name)).join(', ')}.`,
+      'A registry item asked for something that is not a package name. Check the --registry you passed.'
+    );
+  }
+}
+
+/**
  * Installs through `expo install` where possible — it picks versions that
  * match the project's SDK, which plain `npm install` does not.
  */
@@ -221,18 +242,20 @@ export async function installDependencies(
    * goes through the package manager rather than `expo install`, which resolves
    * names against an SDK and has nothing to resolve when given none.
    */
-  const command = installAll
-    ? `${manager} install`
+  const argv = installAll
+    ? [manager, 'install']
     : isExpo
-      ? `npx expo install ${packages.join(' ')}`
-      : `${manager} ${manager === 'npm' ? 'install' : 'add'} ${packages.join(' ')}`;
+      ? ['npx', 'expo', 'install', ...packages]
+      : [manager, manager === 'npm' ? 'install' : 'add', ...packages];
+
+  if (!installAll) assertInstallable(packages);
 
   step(
     installAll
       ? 'Install dependencies'
       : `Install ${packages.length} package${packages.length === 1 ? '' : 's'}`
   );
-  console.log(dim(`  ${command}\n`));
+  console.log(dim(`  ${argv.join(' ')}\n`));
 
   if (dryRun) return;
   if (!(await confirm('Run it?', { assumeYes }))) {
@@ -240,8 +263,14 @@ export async function installDependencies(
     return;
   }
 
-  const [bin, ...args] = command.split(' ');
-  const result = spawnSync(bin, args, { cwd, stdio: 'inherit', shell: process.platform === 'win32' });
+  // Argument vector, never a command string: the package names came from the
+  // registry, and a string would let one of them carry its own arguments.
+  const [bin, ...args] = argv;
+  const result = spawnSync(bin, args, {
+    cwd,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
 
   if (result.status !== 0) {
     fail('Dependency installation failed.', 'Run the command above yourself.');

--- a/packages/cli/src/registry.mjs
+++ b/packages/cli/src/registry.mjs
@@ -6,7 +6,43 @@ import { fail, nearest } from './ui.mjs';
 /** Per-run cache — a closure re-visits shared items like `text` constantly. */
 const cache = new Map();
 
+/** Loopback is the one place cleartext is not a downgrade — nothing is on the wire. */
+function isLoopback(hostname) {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '[::1]' ||
+    hostname === '::1' ||
+    hostname.endsWith('.localhost')
+  );
+}
+
+/**
+ * Whatever the registry returns is written into the project as source, so the
+ * answer has to be known to come from the host that was asked. Cleartext gives
+ * anyone on the path an edit of that source, which is why it is refused
+ * anywhere but loopback.
+ */
+function assertTransport(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    fail(`Registry URL is not a URL: ${url}.`, 'Pass --registry https://panelui.dev/r');
+  }
+
+  if (parsed.protocol === 'https:') return;
+  if (parsed.protocol === 'http:' && isLoopback(parsed.hostname)) return;
+
+  fail(
+    `Refusing to fetch components over ${parsed.protocol}//.`,
+    'Registry files become source in your project, so they are only fetched over https.'
+  );
+}
+
 async function fetchJson(url) {
+  assertTransport(url);
+
   let response;
   try {
     response = await fetch(url);

--- a/packages/cli/test/assume-yes.test.mjs
+++ b/packages/cli/test/assume-yes.test.mjs
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, test } from 'node:test';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-cli-assume-yes-'));
+after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cli = path.resolve(here, '../bin/panelui.mjs');
+
+function waitForLine(stream) {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => {
+      output += chunk;
+      const newline = output.indexOf('\n');
+      if (newline >= 0) resolve(output.slice(0, newline).trim());
+    });
+    stream.on('error', reject);
+  });
+}
+
+function runInTty(args) {
+  if (process.platform === 'win32' || !fs.existsSync('/usr/bin/expect')) return null;
+  const command = [process.execPath, cli, ...args]
+    .map((part) => `{${String(part).replaceAll('}', '\\}')}}`)
+    .join(' ');
+  const script = [
+    'log_user 1',
+    'set timeout 4',
+    `spawn ${command}`,
+    'expect {',
+    '  timeout { puts \"PROMPT_TIMEOUT\"; exit 124 }',
+    '  eof { catch wait result; exit [lindex $result 3] }',
+    '}',
+  ].join('\n');
+  return new Promise((resolve, reject) => {
+    const child = spawn('/usr/bin/expect', ['-c', script], {
+      env: { ...process.env, NO_COLOR: '1' },
+    });
+    let output = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => (output += chunk));
+    child.stderr.on('data', (chunk) => (output += chunk));
+    child.on('error', reject);
+    child.on('close', (status) => resolve({ status, output }));
+  });
+}
+
+test('--yes crosses init, patch, and add boundaries without opening a prompt', {
+  skip: process.platform === 'win32',
+}, async () => {
+  const registryDir = path.join(tempDir, 'registry');
+  const projectDir = path.join(tempDir, 'project');
+  fs.mkdirSync(registryDir);
+  fs.mkdirSync(projectDir);
+  fs.writeFileSync(
+    path.join(registryDir, 'theme.json'),
+    JSON.stringify({ name: 'theme', files: [{ path: 'theme.css', content: '/* tokens */\n' }] })
+  );
+  fs.writeFileSync(
+    path.join(registryDir, 'button.json'),
+    JSON.stringify({
+      name: 'button',
+      files: [{ path: 'ui/button.tsx', content: 'export const Button = true;\n' }],
+    })
+  );
+
+  const dependencies = Object.fromEntries(
+    [
+      'expo',
+      'uniwind',
+      'tailwindcss',
+      'tailwind-variants',
+      'clsx',
+      'tailwind-merge',
+      'react-native-reanimated',
+      'react-native-safe-area-context',
+      'react-native-gesture-handler',
+    ].map((name) => [name, '*'])
+  );
+  fs.writeFileSync(
+    path.join(projectDir, 'package.json'),
+    JSON.stringify({ name: 'fixture', dependencies })
+  );
+  fs.writeFileSync(path.join(projectDir, 'tsconfig.json'), JSON.stringify({ compilerOptions: {} }));
+
+  const server = spawn(
+    process.execPath,
+    [
+      '-e',
+      `const http=require('node:http'),fs=require('node:fs'),path=require('node:path');const root=process.argv[1];const server=http.createServer((req,res)=>{const file=path.join(root,req.url);if(!fs.existsSync(file)){res.writeHead(404).end();return}res.setHeader('content-type','application/json');res.end(fs.readFileSync(file))});server.listen(0,'127.0.0.1',()=>console.log(server.address().port));`,
+      registryDir,
+    ],
+    { stdio: ['ignore', 'pipe', 'inherit'] }
+  );
+
+  try {
+    const port = await waitForLine(server.stdout);
+    const result = await runInTty([
+      'init',
+      '--cwd',
+      projectDir,
+      '--registry',
+      `http://127.0.0.1:${port}`,
+      '--yes',
+    ]);
+
+    if (!result) return;
+    assert.equal(result.status, 0, result.output);
+    assert.doesNotMatch(result.output, /\? .*\((?:Y\/n|y\/N)\)/, result.output);
+    for (const file of [
+      'panelui.json',
+      'theme.css',
+      'global.css',
+      'metro.config.js',
+      'uniwind-env.d.ts',
+      'css.d.ts',
+    ]) {
+      assert.equal(fs.existsSync(path.join(projectDir, file)), true, `${file} was not written`);
+    }
+
+    const addResult = await runInTty([
+      'add',
+      'button',
+      '--cwd',
+      projectDir,
+      '--registry',
+      `http://127.0.0.1:${port}`,
+      '--yes',
+    ]);
+    if (!addResult) return;
+    assert.equal(addResult.status, 0, addResult.output);
+    assert.doesNotMatch(addResult.output, /\? .*\((?:Y\/n|y\/N)\)/, addResult.output);
+    assert.equal(fs.existsSync(path.join(projectDir, 'components/ui/button.tsx')), true);
+  } finally {
+    server.kill();
+  }
+});

--- a/packages/cli/test/install-safety.test.mjs
+++ b/packages/cli/test/install-safety.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, test } from 'node:test';
+
+import { installDependencies } from '../src/patch.mjs';
+import { CliError } from '../src/ui.mjs';
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-cli-install-safety-'));
+after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+/*
+ * Package names reach a shell on Windows, because `npm` is a `.cmd` shim there
+ * and a shim cannot be spawned without one. These are the shapes that would
+ * carry their own command across that boundary if the names were pasted into a
+ * command string instead of passed as an argument vector.
+ */
+const HOSTILE = [
+  'lodash&&calc',
+  'lodash & calc',
+  'lodash|calc',
+  'lodash;calc',
+  'lodash`calc`',
+  'lodash$(calc)',
+  'lodash\ncalc',
+  '../../etc/passwd',
+  '--registry=http://evil.test',
+  '',
+];
+
+for (const name of HOSTILE) {
+  test(`installDependencies refuses ${JSON.stringify(name)}`, async () => {
+    await assert.rejects(
+      installDependencies(tempDir, [name], { assumeYes: true, dryRun: false, isExpo: false }),
+      CliError
+    );
+  });
+}
+
+test('installDependencies accepts the package shapes the registry actually ships', async () => {
+  const allowed = [
+    'clsx',
+    'expo-haptics',
+    '@expo/ui',
+    '@react-native-masked-view/masked-view',
+    'react-native-reanimated@3.16.1',
+  ];
+
+  // dryRun stops before spawning, so this asserts the names survive validation
+  // rather than asserting anything about the installer itself.
+  await installDependencies(tempDir, allowed, {
+    assumeYes: true,
+    dryRun: true,
+    isExpo: false,
+  });
+});

--- a/packages/cli/test/path-containment.test.mjs
+++ b/packages/cli/test/path-containment.test.mjs
@@ -70,7 +70,7 @@ test('rejects unsafe scaffold names before any project files are created', async
 
   try {
     for (const name of ['../victim', '/victim', 'C:\\victim', '\\victim', '\\\\server\\share']) {
-      await assert.rejects(create({ cwd, name, yes: true }), CliError);
+      await assert.rejects(create({ cwd, name, assumeYes: true }), CliError);
     }
 
     assert.equal(validateProjectName('valid-app'), 'valid-app');

--- a/packages/cli/test/registry-transport.test.mjs
+++ b/packages/cli/test/registry-transport.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { after, test } from 'node:test';
+
+import { fetchIndex } from '../src/registry.mjs';
+import { CliError } from '../src/ui.mjs';
+
+/*
+ * Registry files are written into the project as source, so the transport is
+ * the only thing standing between a component and an edit of it in flight.
+ */
+test('a cleartext registry on a remote host is refused', async () => {
+  await assert.rejects(fetchIndex('http://registry.example.com/r'), CliError);
+});
+
+test('other schemes are refused rather than attempted', async () => {
+  for (const registry of ['file:///etc', 'ftp://registry.example.com', 'not-a-url']) {
+    await assert.rejects(fetchIndex(registry), CliError);
+  }
+});
+
+test('https is allowed through to the network layer', async () => {
+  // Resolution is expected to fail; what matters is that it failed at the
+  // fetch rather than at the transport check.
+  await assert.rejects(fetchIndex('https://registry.invalid/r'), (error) => {
+    assert.ok(error instanceof CliError);
+    assert.match(error.message, /Could not reach the registry/);
+    return true;
+  });
+});
+
+test('loopback over http still works, so local development is not blocked', async () => {
+  const server = http.createServer((_request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify([{ name: 'button' }]));
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  after(() => server.close());
+
+  const index = await fetchIndex(`http://127.0.0.1:${server.address().port}`);
+  assert.deepEqual(index, [{ name: 'button' }]);
+});

--- a/packages/create-panelui-app/index.mjs
+++ b/packages/create-panelui-app/index.mjs
@@ -38,7 +38,12 @@ ${bold('Examples')}
 `;
 
 function parseArgs(argv) {
-  const options = { cwd: process.cwd(), yes: false, template: undefined, theme: undefined };
+  const options = {
+    cwd: process.cwd(),
+    assumeYes: false,
+    template: undefined,
+    theme: undefined,
+  };
   let help = false;
   let version = false;
 
@@ -47,7 +52,7 @@ function parseArgs(argv) {
     switch (arg) {
       case '--yes':
       case '-y':
-        options.yes = true;
+        options.assumeYes = true;
         break;
       case '--help':
       case '-h':


### PR DESCRIPTION
## Summary
- normalize --yes/-y to one internal assumeYes option
- propagate it consistently through init, project creation, add, CSS/Metro/TypeScript patching, and dependency installation
- preserve current path containment and fatal install-failure behavior
- add a real pseudo-terminal regression proving init/add do not open prompts

## Why
The parser emitted options.yes while lower-level patch and install helpers read assumeYes. Top-level prompts were skipped, but valid --yes invocations could still block inside helper boundaries.

## Validation
- node --test packages/cli/test/*.test.mjs: 8 passed
- PTY scenario covers init configuration/theme/CSS/Metro/TypeScript/dependencies and add confirmation
- npm run typecheck across PanelUI, docs, and example
- npm run build (146 PanelUI modules)
- git diff --check

## Portability note
The true TTY assertion uses /usr/bin/expect and skips where unavailable or on Windows; static option-contract coverage and the rest of the CLI suite still run there.

## Coordination
This PR and #59 both touch the two command parsers but address independent contracts. If #59 merges first, this branch only needs the small parser hunks rebased while retaining assumeYes propagation and PTY coverage.