### PR TITLE
docs: credit OpenPanel for the analytics

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -272,7 +272,20 @@ export default function HomePage() {
       {/* Footer */}
       <footer className="border-t px-6 py-10">
         <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 text-sm text-muted-foreground sm:flex-row">
-          <p>MIT © Khalid Abdi</p>
+          <div className="flex flex-col items-center gap-1 sm:items-start">
+            <p>MIT © Khalid Abdi</p>
+            <p>
+              Analytics provided by{' '}
+              <a
+                href="https://openpanel.dev"
+                target="_blank"
+                rel="noreferrer"
+                className="hover:text-foreground"
+              >
+                OpenPanel
+              </a>
+            </p>
+          </div>
           <nav className="flex gap-6" aria-label="Footer">
             <Link href="/docs" prefetch={false} className="hover:text-foreground">
               Documentation

--- a/packages/panelui/README.md
+++ b/packages/panelui/README.md
@@ -11,6 +11,7 @@ Zero native code, so it runs in Expo Go.
 [![MIT license](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/panel-ui/PanelUI/blob/main/LICENSE)
 ![platforms iOS and Android](https://img.shields.io/badge/platforms-iOS%20%7C%20Android-black?style=flat-square)
 ![Expo SDK 57+](https://img.shields.io/badge/Expo-SDK%2057%2B-000?style=flat-square&logo=expo)
+[![analytics by OpenPanel](https://shieldcn.dev/badge/analytics%20by-OpenPanel-2564EB.svg?logo=openpanel&logoColor=fff&variant=branded&brand=openpanel)](https://openpanel.dev)
 
 - ⚡ **Tailwind CSS for React Native** via [Uniwind](https://uniwind.dev) — no Babel transform,
   roughly 2.4–3× faster styling than NativeWind.


### PR DESCRIPTION
The site records its traffic through OpenPanel. This adds the credit in two places:

- **Landing page footer** — "Analytics provided by OpenPanel", with OpenPanel linking to their site.
- **Published package README** — their badge, linked to openpanel.dev.

Verified: `typecheck`, `docs` build (compiles, 138 pages), docs tests, and `docs:generate` leaves no drift. Badge URL and destination both return 200.

Note: the package README's other badges are shields.io `flat-square`, so the shieldcn branded badge sits in a row it does not match. The root `README.md` already uses shieldcn throughout — say the word and I'll migrate the package README's row to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)