### PR TITLE
docs: underline the footer credit, and badge the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/panelui-native"><img alt="npm version and monthly downloads" src="https://shieldcn.dev/group/npm/v/panelui-native+npm/dm/panelui-native.svg?variant=branded&amp;size=xs" /></a>
   <a href="https://github.com/panel-ui/PanelUI"><img alt="GitHub stars, license, contributors and last commit" src="https://shieldcn.dev/group/github/panel-ui/PanelUI/stars+github/panel-ui/PanelUI/license+github/panel-ui/PanelUI/contributors+github/panel-ui/PanelUI/last-commit.svg?variant=branded&amp;size=xs" /></a>
+  <a href="https://openpanel.dev"><img alt="analytics by OpenPanel" src="https://shieldcn.dev/badge/analytics%20by-OpenPanel-2564EB.svg?logo=openpanel&amp;logoColor=fff&amp;variant=branded&amp;brand=openpanel&amp;size=xs" /></a>
 </p>
 
 <p align="center">

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -280,7 +280,7 @@ export default function HomePage() {
                 href="https://openpanel.dev"
                 target="_blank"
                 rel="noreferrer"
-                className="hover:text-foreground"
+                className="underline underline-offset-4 hover:text-foreground"
               >
                 OpenPanel
               </a>


### PR DESCRIPTION
Two follow-ups to the OpenPanel credit:

- **Footer link is underlined.** It was distinguishable only on hover, so a reader with the pointer elsewhere had no signal it was a link. `underline underline-offset-4`, keeping the existing hover colour.
- **Root README carries the badge.** Added at `size=xs` so it matches the two grouped badges already in that row — the URL is otherwise exactly as supplied.

Verified: docs typecheck, docs tests, and a full docs build (compiles). Badge URL returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)