### PR TITLE
fix(cli): repair dependencies on repeated adds

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,7 +35,8 @@ npx panelui-cli@latest init
 ### `add <name...>`
 
 Copies components in, along with everything they depend on. A component you already have is
-left alone — those files are yours once copied.
+left alone — those files are yours once copied. Re-running the command still installs any missing
+packages required by those files.
 
 ```bash
 npx panelui-cli@latest add item message

--- a/packages/cli/src/add.mjs
+++ b/packages/cli/src/add.mjs
@@ -66,26 +66,24 @@ export async function add(names, options) {
   }
 
   const pending = writes.filter((w) => options.overwrite || !w.exists);
-  if (!pending.length) {
-    success('Everything is already installed.');
-    return;
-  }
-
   if (options.dryRun) {
     info(dim('Dry run — nothing written.'));
-    return;
-  }
+  } else if (pending.length) {
+    if (
+      !(await confirm(`Write ${pending.length} file${pending.length === 1 ? '' : 's'}?`, options))
+    ) {
+      info(dim('Cancelled.'));
+      return;
+    }
 
-  if (!(await confirm(`Write ${pending.length} file${pending.length === 1 ? '' : 's'}?`, options))) {
-    info(dim('Cancelled.'));
-    return;
+    for (const write of pending) {
+      fs.mkdirSync(path.dirname(write.destination), { recursive: true });
+      fs.writeFileSync(write.destination, write.content);
+    }
+    success(`Wrote ${pending.length} file${pending.length === 1 ? '' : 's'}`);
+  } else {
+    success('Component files are already installed.');
   }
-
-  for (const write of pending) {
-    fs.mkdirSync(path.dirname(write.destination), { recursive: true });
-    fs.writeFileSync(write.destination, write.content);
-  }
-  success(`Wrote ${pending.length} file${pending.length === 1 ? '' : 's'}`);
 
   const { dependencies, optionalDependencies } = collectDependencies(items);
   const missing = dependencies.filter((dep) => !(dep in project.deps));

--- a/packages/cli/test/add-dependency-repair.test.mjs
+++ b/packages/cli/test/add-dependency-repair.test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { after, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-cli-dependency-repair-'));
+after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cli = path.resolve(here, '../bin/panelui.mjs');
+
+function waitForLine(stream) {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => {
+      output += chunk;
+      const newline = output.indexOf('\n');
+      if (newline >= 0) resolve(output.slice(0, newline).trim());
+    });
+    stream.on('error', reject);
+  });
+}
+
+test('add repairs dependencies when every resolved component file already exists', {
+  skip: process.platform === 'win32',
+}, async () => {
+  const registryDir = path.join(tempDir, 'registry');
+  const projectDir = path.join(tempDir, 'project');
+  const binDir = path.join(tempDir, 'bin');
+  const installLog = path.join(tempDir, 'install.log');
+  fs.mkdirSync(registryDir);
+  fs.mkdirSync(path.join(projectDir, 'components/ui'), { recursive: true });
+  fs.mkdirSync(binDir);
+
+  fs.writeFileSync(
+    path.join(registryDir, 'button.json'),
+    JSON.stringify({
+      name: 'button',
+      registryDependencies: ['helper'],
+      files: [{ path: 'ui/button.tsx', content: 'registry button\n' }],
+    })
+  );
+  fs.writeFileSync(
+    path.join(registryDir, 'helper.json'),
+    JSON.stringify({
+      name: 'helper',
+      dependencies: ['repair-package'],
+      files: [{ path: 'ui/helper.tsx', content: 'registry helper\n' }],
+    })
+  );
+  fs.writeFileSync(
+    path.join(projectDir, 'panelui.json'),
+    JSON.stringify({
+      registry: 'https://panelui.dev/r',
+      aliases: {
+        components: '@/components/ui',
+        lib: '@/lib',
+        hooks: '@/hooks',
+      },
+      theme: 'theme.css',
+    })
+  );
+  fs.writeFileSync(path.join(projectDir, 'package.json'), JSON.stringify({ dependencies: {} }));
+  fs.writeFileSync(path.join(projectDir, 'components/ui/button.tsx'), 'owned button\n');
+  fs.writeFileSync(path.join(projectDir, 'components/ui/helper.tsx'), 'owned helper\n');
+
+  const fakeNpm = path.join(binDir, 'npm');
+  fs.writeFileSync(fakeNpm, '#!/bin/sh\nprintf "%s\\n" "$@" > "$PANELUI_INSTALL_LOG"\n');
+  fs.chmodSync(fakeNpm, 0o755);
+
+  const server = spawn(
+    process.execPath,
+    [
+      '-e',
+      `const http=require('node:http'),fs=require('node:fs'),path=require('node:path');const root=process.argv[1];const server=http.createServer((req,res)=>{const file=path.join(root,req.url);if(!fs.existsSync(file)){res.writeHead(404).end();return}res.setHeader('content-type','application/json');res.end(fs.readFileSync(file))});server.listen(0,'127.0.0.1',()=>console.log(server.address().port));`,
+      registryDir,
+    ],
+    { stdio: ['ignore', 'pipe', 'inherit'] }
+  );
+
+  try {
+    const port = await waitForLine(server.stdout);
+    const result = spawnSync(
+      process.execPath,
+      [
+        cli,
+        'add',
+        'button',
+        '--cwd',
+        projectDir,
+        '--registry',
+        `http://127.0.0.1:${port}`,
+        '--yes',
+      ],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          NO_COLOR: '1',
+          PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+          PANELUI_INSTALL_LOG: installLog,
+        },
+      }
+    );
+
+    const output = `${result.stdout}${result.stderr}`;
+    assert.equal(result.status, 0, output);
+    assert.equal(fs.readFileSync(path.join(projectDir, 'components/ui/button.tsx'), 'utf8'), 'owned button\n');
+    assert.equal(fs.readFileSync(path.join(projectDir, 'components/ui/helper.tsx'), 'utf8'), 'owned helper\n');
+    assert.equal(fs.readFileSync(installLog, 'utf8'), 'install\nrepair-package\n');
+    assert.match(output, /Component files are already installed\./);
+    assert.match(output, /Dependencies installed/);
+  } finally {
+    server.kill();
+  }
+});


### PR DESCRIPTION
## Summary
- preserve existing component files unless `--overwrite` is requested
- continue dependency reconciliation when every resolved file already exists
- keep dry-run output truthful and document repeated-add repair behavior
- add an end-to-end transitive dependency regression

## Why
A repeated `add` returned before dependency collection and installation when all resolved files already existed. That left partial installs missing required packages even though the CLI reported everything installed.

## Validation
- `node --experimental-strip-types --test packages/cli/test/*.test.mjs` — 31/31 passed
- `npm run typecheck` — passed
- `npm run build` — passed (153 source files)
- `npm pack --workspace=panelui-cli --dry-run --json` — passed
- `git diff --check origin/main...HEAD` — passed

The subprocess regression is skipped on Windows because its fake npm executable is a POSIX shell script; the changed control flow is platform-neutral.