### PR TITLE
fix(cli): enforce MCP transport contracts

### DIFF
--- a/packages/cli/src/mcp.mjs
+++ b/packages/cli/src/mcp.mjs
@@ -16,12 +16,8 @@ import path from 'node:path';
 import process from 'node:process';
 import { DEFAULT_REGISTRY, aliasToDir, projectPath, readConfig } from './config.mjs';
 
-/**
- * The version we speak. The spec says to answer with the client's version when
- * we support it and ours when we do not, so a newer client downgrades rather
- * than failing.
- */
 const PROTOCOL_VERSION = '2025-06-18';
+const SUPPORTED_PROTOCOL_VERSIONS = [PROTOCOL_VERSION];
 
 const { default: pkg } = await import('../package.json', { with: { type: 'json' } });
 
@@ -316,10 +312,16 @@ async function handle(message, options) {
   if (id === undefined) return;
 
   switch (method) {
-    case 'initialize':
+    case 'initialize': {
+      const requested = params?.protocolVersion;
+      if (typeof requested !== 'string') {
+        return failure(id, -32602, 'Invalid params: protocolVersion must be a string');
+      }
+
       return result(id, {
-        protocolVersion:
-          typeof params.protocolVersion === 'string' ? params.protocolVersion : PROTOCOL_VERSION,
+        protocolVersion: SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+          ? requested
+          : PROTOCOL_VERSION,
         capabilities: { tools: {} },
         serverInfo: { name: 'panelui', version: pkg.version },
         instructions:
@@ -328,6 +330,7 @@ async function handle(message, options) {
           'components already exist. Then panelui_search_components before writing any custom ' +
           'UI, and panelui_get_component_docs before using one.',
       });
+    }
 
     case 'tools/list':
       return result(id, { tools: TOOLS });
@@ -354,6 +357,21 @@ async function handle(message, options) {
   }
 }
 
+async function receive(line, options) {
+  const text = line.trim();
+  if (!text) return;
+
+  let message;
+  try {
+    message = JSON.parse(text);
+  } catch {
+    failure(null, -32700, 'Parse error');
+    return;
+  }
+
+  await handle(message, options);
+}
+
 export async function mcp(options) {
   process.stdin.setEncoding('utf8');
 
@@ -363,21 +381,13 @@ export async function mcp(options) {
 
     let newline;
     while ((newline = buffer.indexOf('\n')) !== -1) {
-      const line = buffer.slice(0, newline).trim();
+      const line = buffer.slice(0, newline);
       buffer = buffer.slice(newline + 1);
-      if (!line) continue;
-
-      let message;
-      try {
-        message = JSON.parse(line);
-      } catch {
-        failure(null, -32700, 'Parse error');
-        continue;
-      }
-
-      await handle(message, options);
+      await receive(line, options);
     }
   }
+
+  await receive(buffer, options);
 }
 
 /* ------------------------------------------------------------------ *

--- a/packages/cli/src/mcp.mjs
+++ b/packages/cli/src/mcp.mjs
@@ -16,6 +16,14 @@ import path from 'node:path';
 import process from 'node:process';
 import { DEFAULT_REGISTRY, aliasToDir, projectPath, readConfig } from './config.mjs';
 
+/**
+ * The versions we speak, and the one we answer with otherwise.
+ *
+ * The spec says to reply with the client's version when it is one we support
+ * and with our own when it is not, so a newer client is told what it is talking
+ * to and can decide to downgrade rather than being refused. Echoing back
+ * whatever arrived would claim support for a protocol nothing here implements.
+ */
 const PROTOCOL_VERSION = '2025-06-18';
 const SUPPORTED_PROTOCOL_VERSIONS = [PROTOCOL_VERSION];
 

--- a/packages/cli/test/mcp-transport.test.mjs
+++ b/packages/cli/test/mcp-transport.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cli = path.resolve(here, '../bin/panelui.mjs');
+
+function request(id, method, params) {
+  return JSON.stringify({ jsonrpc: '2.0', id, method, ...(params ? { params } : {}) });
+}
+
+function run(input) {
+  const server = spawnSync(process.execPath, [cli, 'mcp'], { encoding: 'utf8', input });
+  assert.equal(server.status, 0, server.stderr);
+  assert.equal(server.stderr, '');
+  return server.stdout
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+test('initialization negotiates unsupported versions to the server version', () => {
+  const [reply] = run(
+    `${request(1, 'initialize', {
+      protocolVersion: '2099-01-01',
+      capabilities: {},
+      clientInfo: { name: 'transport-test', version: '1.0.0' },
+    })}\n`
+  );
+
+  assert.equal(reply.id, 1);
+  assert.equal(reply.result.protocolVersion, '2025-06-18');
+});
+
+test('initialization accepts the protocol version the server implements', () => {
+  const [reply] = run(
+    `${request(2, 'initialize', {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'transport-test', version: '1.0.0' },
+    })}\n`
+  );
+
+  assert.equal(reply.id, 2);
+  assert.equal(reply.result.protocolVersion, '2025-06-18');
+});
+
+test('initialization rejects missing and non-string protocol versions', () => {
+  for (const protocolVersion of [undefined, null, 20250618]) {
+    const params = {
+      capabilities: {},
+      clientInfo: { name: 'transport-test', version: '1.0.0' },
+      ...(protocolVersion === undefined ? {} : { protocolVersion }),
+    };
+    const [reply] = run(`${request(8, 'initialize', params)}\n`);
+
+    assert.deepEqual(reply, {
+      jsonrpc: '2.0',
+      id: 8,
+      error: { code: -32602, message: 'Invalid params: protocolVersion must be a string' },
+    });
+  }
+});
+
+test('processes a complete final message when stdin ends without a newline', () => {
+  assert.deepEqual(run(request(3, 'ping')), [{ jsonrpc: '2.0', id: 3, result: {} }]);
+});
+
+test('keeps newline-delimited messages ordered and reports malformed messages', () => {
+  const replies = run(
+    `${request(4, 'ping')}\nnot-json\n${request(5, 'ping')}\n${request(6, 'ping')}`
+  );
+
+  assert.deepEqual(replies, [
+    { jsonrpc: '2.0', id: 4, result: {} },
+    { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } },
+    { jsonrpc: '2.0', id: 5, result: {} },
+    { jsonrpc: '2.0', id: 6, result: {} },
+  ]);
+});
+
+test('buffers a message split across stdin chunks', async () => {
+  const server = spawn(process.execPath, [cli, 'mcp'], { stdio: ['pipe', 'pipe', 'pipe'] });
+  let stdout = '';
+  let stderr = '';
+  server.stdout.setEncoding('utf8');
+  server.stderr.setEncoding('utf8');
+  server.stdout.on('data', (chunk) => (stdout += chunk));
+  server.stderr.on('data', (chunk) => (stderr += chunk));
+
+  const message = request(7, 'ping');
+  server.stdin.write(message.slice(0, 12));
+  await new Promise((resolve) => setImmediate(resolve));
+  server.stdin.end(message.slice(12));
+
+  const exitCode = await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.once('close', resolve);
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(stderr, '');
+  assert.deepEqual(JSON.parse(stdout.trim()), { jsonrpc: '2.0', id: 7, result: {} });
+});


### PR DESCRIPTION
## Summary
- negotiate unsupported valid MCP versions to the server's supported `2025-06-18` version
- reject missing or non-string `protocolVersion` values as invalid params
- process a complete final JSON-RPC message when stdin closes without a trailing newline
- cover fragmented, ordered, empty-line, malformed, and initialization transport behavior

## Why
The stdio server dropped a complete residual request at EOF and accepted malformed initialization parameters. The explicit negotiation path now follows the MCP lifecycle contract while preserving newline-delimited ordering.

## Validation
- focused MCP transport tests — 6/6 passed
- full CLI suite — 36/36 passed
- Node syntax checks — passed
- `npm pack --workspace=panelui-cli --dry-run --json` — passed
- `git diff --check origin/main...HEAD` — passed