### PR TITLE
fix(cli): verify the exported Metro wrapper

### DIFF
--- a/packages/cli/src/patch.mjs
+++ b/packages/cli/src/patch.mjs
@@ -93,6 +93,90 @@ module.exports = withUniwindConfig(config, {
 });
 `;
 
+/** Remove text that cannot participate in an exported JavaScript expression. */
+function codeOnly(source) {
+  let output = '';
+  let state = 'code';
+
+  for (let index = 0; index < source.length; index++) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (state === 'code') {
+      if (char === '/' && next === '/') {
+        output += '  ';
+        index += 1;
+        state = 'line-comment';
+      } else if (char === '/' && next === '*') {
+        output += '  ';
+        index += 1;
+        state = 'block-comment';
+      } else if (char === "'" || char === '"' || char === '`') {
+        output += ' ';
+        state = char;
+      } else {
+        output += char;
+      }
+    } else if (state === 'line-comment') {
+      output += char === '\n' ? '\n' : ' ';
+      if (char === '\n') state = 'code';
+    } else if (state === 'block-comment') {
+      if (char === '*' && next === '/') {
+        output += '  ';
+        index += 1;
+        state = 'code';
+      } else {
+        output += char === '\n' ? '\n' : ' ';
+      }
+    } else if (char === '\\') {
+      output += ' ';
+      if (next !== undefined) {
+        output += next === '\n' ? '\n' : ' ';
+        index += 1;
+      }
+    } else {
+      output += char === '\n' ? '\n' : ' ';
+      if (char === state) state = 'code';
+    }
+  }
+
+  return output;
+}
+
+/**
+ * True only when the exported value itself is visibly wrapped.
+ *
+ * This deliberately recognises fewer shapes than a JavaScript parser could.
+ * Existing Metro configs are never edited, so an unfamiliar but valid shape
+ * gets safe manual instructions instead of a false claim that setup is done.
+ */
+function hasWrappedMetroExport(source) {
+  const code = codeOnly(source);
+  const wrapperCall = String.raw`(?:\(\s*)*withUniwindConfig\s*\(`;
+  const directExports = [
+    new RegExp(String.raw`\bmodule\s*\.\s*exports\s*=\s*${wrapperCall}`),
+    new RegExp(String.raw`\bexport\s+default\s+${wrapperCall}`),
+  ];
+  if (directExports.some((pattern) => pattern.test(code))) return true;
+
+  // A named const is still conservative: it cannot be reassigned between the
+  // wrapper call and the CommonJS/ESM export that refers to it.
+  const namedExports = [
+    /\bmodule\s*\.\s*exports\s*=\s*([A-Za-z_$][\w$]*)[ \t]*(?:;|$)/gm,
+    /\bexport\s+default\s+([A-Za-z_$][\w$]*)[ \t]*(?:;|$)/gm,
+  ];
+  for (const pattern of namedExports) {
+    for (const match of code.matchAll(pattern)) {
+      const declaration = new RegExp(
+        String.raw`\bconst\s+${match[1]}\s*=\s*${wrapperCall}`
+      );
+      if (declaration.test(code.slice(0, match.index))) return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Metro has to know about the CSS entry and the extra themes.
  *
@@ -118,7 +202,7 @@ export async function patchMetro(cwd, config, { assumeYes, dryRun }) {
   }
 
   const current = fs.readFileSync(metroPath, 'utf8');
-  if (current.includes('withUniwindConfig')) {
+  if (hasWrappedMetroExport(current)) {
     success('metro.config.js already wraps withUniwindConfig');
     return;
   }

--- a/packages/cli/test/patch-metro.test.mjs
+++ b/packages/cli/test/patch-metro.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import { patchMetro } from '../src/patch.mjs';
+
+async function runPatch(contents) {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-cli-metro-'));
+  fs.writeFileSync(path.join(cwd, 'metro.config.js'), contents);
+
+  const output = [];
+  const originalLog = console.log;
+  console.log = (...args) => output.push(args.join(' '));
+  try {
+    await patchMetro(cwd, {}, { assumeYes: true, dryRun: false });
+  } finally {
+    console.log = originalLog;
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+  return output.join('\n');
+}
+
+for (const [label, contents] of [
+  [
+    'CommonJS',
+    `const { withUniwindConfig } = require('uniwind/metro');
+const config = {};
+module.exports = withUniwindConfig(config, { cssEntryFile: './global.css' });
+`,
+  ],
+  [
+    'ES modules',
+    `import { withUniwindConfig } from 'uniwind/metro';
+const config = {};
+export default withUniwindConfig(config, { cssEntryFile: './global.css' });
+`,
+  ],
+  [
+    'named CommonJS',
+    `const { withUniwindConfig } = require('uniwind/metro');
+const config = {};
+const wrappedConfig = withUniwindConfig(config, { cssEntryFile: './global.css' });
+module.exports = wrappedConfig
+`,
+  ],
+]) {
+  test(`patchMetro accepts a wrapped ${label} export`, async () => {
+    const output = await runPatch(contents);
+    assert.match(output, /already wraps withUniwindConfig/);
+    assert.doesNotMatch(output, /does not use Uniwind/);
+  });
+}
+
+for (const [label, contents] of [
+  [
+    'comment',
+    `const config = {};
+// module.exports = withUniwindConfig(config);
+module.exports = config;
+`,
+  ],
+  [
+    'unused import',
+    `import { withUniwindConfig } from 'uniwind/metro';
+const config = {};
+export default config;
+`,
+  ],
+]) {
+  test(`patchMetro rejects a withUniwindConfig ${label} outside the export`, async () => {
+    const output = await runPatch(contents);
+    assert.match(output, /does not use Uniwind/);
+    assert.doesNotMatch(output, /already wraps withUniwindConfig/);
+  });
+}


### PR DESCRIPTION
## Summary
- verify the actual exported Metro expression instead of searching for an identifier substring
- recognize directly wrapped CommonJS/ESM exports and immutable named wrapper exports
- reject false positives from comments and unused imports
- keep unfamiliar user-owned config shapes untouched and show the existing manual instructions

## Why
Any withUniwindConfig substring previously counted as successful setup. A comment or unused import could therefore make init report success while the exported Metro configuration remained unwrapped and styling stayed broken.

## Validation
- focused Metro patch tests — 5/5 passed
- full CLI suite — 35/35 passed
- root typecheck — passed
- root build — passed (153 source files)
- panelui-cli package dry-run — passed
- git diff check — passed

This is intentionally conservative rather than a complete JavaScript parser. Ambiguous valid shapes may receive manual instructions, which is safer than rewriting user-owned Metro config or reporting false success.