### PR TITLE
perf(cli): fetch registry dependencies concurrently

### DIFF
--- a/packages/cli/src/registry.mjs
+++ b/packages/cli/src/registry.mjs
@@ -3,8 +3,10 @@
  */
 import { fail, nearest } from './ui.mjs';
 
-/** Per-run cache — a closure re-visits shared items like `text` constantly. */
+/** Share completed and in-flight item requests within this CLI process. */
 const cache = new Map();
+/** Overlap registry round trips without opening an unbounded connection burst. */
+const FETCH_CONCURRENCY = 6;
 
 /** Loopback is the one place cleartext is not a downgrade — nothing is on the wire. */
 function isLoopback(hostname) {
@@ -68,25 +70,83 @@ export async function fetchIndex(registry) {
 }
 
 export async function fetchItem(registry, name) {
-  if (cache.has(name)) return cache.get(name);
+  const key = `${registry}\0${name}`;
+  if (cache.has(key)) return cache.get(key);
 
-  const item = await fetchJson(`${registry}/${name}.json`);
-  if (!item) {
-    const index = await fetchIndex(registry);
-    const suggestion = nearest(
-      name,
-      index.map((entry) => entry.name)
-    );
-    fail(
-      `No component called "${name}".`,
-      suggestion
-        ? `Did you mean "${suggestion}"?`
-        : 'Run `npx panelui-cli@latest list` to see what is available.'
-    );
+  const request = (async () => {
+    const item = await fetchJson(`${registry}/${name}.json`);
+    if (!item) {
+      const index = await fetchIndex(registry);
+      const suggestion = nearest(
+        name,
+        index.map((entry) => entry.name)
+      );
+      fail(
+        `No component called "${name}".`,
+        suggestion
+          ? `Did you mean "${suggestion}"?`
+          : 'Run `npx panelui-cli@latest list` to see what is available.'
+      );
+    }
+
+    return item;
+  })();
+
+  cache.set(key, request);
+
+  try {
+    return await request;
+  } catch (error) {
+    // A transient failure was never cached before. Keep that retry-on-next-call
+    // behavior while still sharing this attempt with concurrent callers.
+    if (cache.get(key) === request) cache.delete(key);
+    throw error;
   }
+}
 
-  cache.set(name, item);
-  return item;
+async function fetchGraph(registry, names) {
+  const items = new Map();
+  const errors = new Map();
+  const queued = new Set();
+  const queue = [];
+  let cursor = 0;
+  let active = 0;
+
+  const enqueue = (name) => {
+    if (queued.has(name)) return;
+    queued.add(name);
+    queue.push(name);
+  };
+  for (const name of names) enqueue(name);
+
+  await new Promise((done) => {
+    const pump = () => {
+      while (active < FETCH_CONCURRENCY && cursor < queue.length) {
+        const name = queue[cursor++];
+        active++;
+
+        fetchItem(registry, name)
+          .then(
+            (item) => {
+              items.set(name, item);
+              for (const dependency of item.registryDependencies ?? []) enqueue(dependency);
+            },
+            (error) => errors.set(name, error)
+          )
+          .finally(() => {
+            active--;
+            if (active === 0 && cursor >= queue.length) done();
+            else pump();
+          });
+      }
+
+      if (active === 0 && cursor >= queue.length) done();
+    };
+
+    pump();
+  });
+
+  return { items, errors };
 }
 
 /**
@@ -97,21 +157,25 @@ export async function fetchItem(registry, name) {
  * the visited set makes that irrelevant either way.
  */
 export async function resolve(registry, names) {
+  const graph = await fetchGraph(registry, names);
   const resolved = new Map();
 
-  async function visit(name) {
+  function visit(name) {
     if (resolved.has(name)) return;
 
-    const item = await fetchItem(registry, name);
+    if (graph.errors.has(name)) throw graph.errors.get(name);
+    const item = graph.items.get(name);
     // Marked before recursing so a cycle could not loop forever.
     resolved.set(name, item);
 
     for (const dependency of item.registryDependencies ?? []) {
-      await visit(dependency);
+      visit(dependency);
     }
   }
 
-  for (const name of names) await visit(name);
+  // Fetch completion order is deliberately ignored. A second DFS preserves the
+  // requested and dependency order callers already see in dry-run output.
+  for (const name of names) visit(name);
 
   return [...resolved.values()];
 }

--- a/packages/cli/test/registry-concurrency.test.mjs
+++ b/packages/cli/test/registry-concurrency.test.mjs
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { fetchItem, resolve } from '../src/registry.mjs';
+import { CliError } from '../src/ui.mjs';
+
+function response(body, status = 200) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    async json() {
+      return body;
+    },
+  };
+}
+
+function item(name, registryDependencies = []) {
+  return { name, registryDependencies, files: [] };
+}
+
+function nameFrom(url) {
+  return new URL(url).pathname.split('/').at(-1).replace(/\.json$/, '');
+}
+
+async function waitFor(predicate) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.fail('scheduler did not reach the expected state');
+}
+
+test('dependency frontiers fetch six at a time and retain declaration order', async (context) => {
+  const registry = 'https://bounded.test/r';
+  const dependencies = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+  const waiting = new Map();
+  const requests = [];
+  let active = 0;
+  let maximum = 0;
+
+  context.mock.method(globalThis, 'fetch', async (url) => {
+    const name = nameFrom(url);
+    requests.push(name);
+    if (name === 'root') return response(item('root', dependencies));
+
+    active++;
+    maximum = Math.max(maximum, active);
+    await new Promise((release) => waiting.set(name, release));
+    waiting.delete(name);
+    active--;
+    return response(item(name));
+  });
+
+  const resultPromise = resolve(registry, ['root']);
+  await waitFor(() => waiting.size === 6);
+  assert.equal(maximum, 6);
+  assert.deepEqual(requests, ['root', 'a', 'b', 'c', 'd', 'e', 'f']);
+
+  for (const name of [...waiting.keys()].reverse()) waiting.get(name)();
+  await waitFor(() => requests.includes('g') && requests.includes('h'));
+  for (const release of waiting.values()) release();
+
+  const result = await resultPromise;
+  assert.deepEqual(
+    result.map((entry) => entry.name),
+    ['root', ...dependencies]
+  );
+});
+
+test('shared dependencies and cycles fetch once and keep depth-first output', async (context) => {
+  const registry = 'https://dedupe.test/r';
+  const graph = {
+    root: item('root', ['left', 'right']),
+    left: item('left', ['shared']),
+    right: item('right', ['shared']),
+    shared: item('shared', ['root']),
+  };
+  const requests = new Map();
+
+  context.mock.method(globalThis, 'fetch', async (url) => {
+    const name = nameFrom(url);
+    requests.set(name, (requests.get(name) ?? 0) + 1);
+    return response(graph[name]);
+  });
+
+  const result = await resolve(registry, ['root']);
+  assert.deepEqual(
+    result.map((entry) => entry.name),
+    ['root', 'left', 'shared', 'right']
+  );
+  assert.deepEqual(Object.fromEntries(requests), { root: 1, left: 1, right: 1, shared: 1 });
+});
+
+test('concurrent and later item reads share one request', async (context) => {
+  const registry = 'https://cache.test/r';
+  let requests = 0;
+  let release;
+  context.mock.method(globalThis, 'fetch', async () => {
+    requests++;
+    await new Promise((resolve) => {
+      release = resolve;
+    });
+    return response(item('shared'));
+  });
+
+  const first = fetchItem(registry, 'shared');
+  const second = fetchItem(registry, 'shared');
+  await waitFor(() => release !== undefined);
+  assert.equal(requests, 1);
+  release();
+
+  const [firstItem, secondItem] = await Promise.all([first, second]);
+  const laterItem = await fetchItem(registry, 'shared');
+  assert.equal(firstItem, secondItem);
+  assert.equal(firstItem, laterItem);
+  assert.equal(requests, 1);
+});
+
+test('missing items retain the registry error and suggestion path', async (context) => {
+  const registry = 'https://missing.test/r';
+  context.mock.method(globalThis, 'fetch', async (url) => {
+    const name = nameFrom(url);
+    if (name === 'root') return response(item('root', ['buton']));
+    if (name === 'index') return response([{ name: 'button' }]);
+    return response(null, 404);
+  });
+
+  await assert.rejects(resolve(registry, ['root']), (error) => {
+    assert.ok(error instanceof CliError);
+    assert.match(error.message, /No component called "buton"/);
+    assert.match(error.hint, /Did you mean "button"/);
+    return true;
+  });
+});
+
+test('empty and dependency-free requests do no extra work', async (context) => {
+  const registry = 'https://empty.test/r';
+  let requests = 0;
+  context.mock.method(globalThis, 'fetch', async (url) => {
+    requests++;
+    return response(item(nameFrom(url)));
+  });
+
+  assert.deepEqual(await resolve(registry, []), []);
+  assert.deepEqual(
+    (await resolve(registry, ['standalone'])).map((entry) => entry.name),
+    ['standalone']
+  );
+  assert.equal(requests, 1);
+});


### PR DESCRIPTION
## Summary
- fetch registry dependency frontiers with a six-request concurrency cap
- cache in-flight and completed item requests by registry and item name
- deduplicate shared dependencies and cycles before scheduling
- separate graph fetching from deterministic dependency-order traversal
- add deterministic bounded-concurrency, caching, cycle, error, and empty-graph tests

## Why
Registry dependencies were awaited recursively one at a time, multiplying network round-trip latency. The completed-only cache also could not deduplicate concurrent reads.

## Validation
- focused registry concurrency tests — 5/5 passed
- full CLI suite — 35/35 passed
- root typecheck and build — passed
- panelui-cli package dry-run — passed
- git diff check — passed

No retry/backoff policy is added in this PR because the current fetch contract has no retry classification. Failed requests are evicted so a later invocation can retry.