### PR TITLE
fix(docs): add composite keyboard navigation

### DIFF
--- a/apps/docs/components/composite-keyboard.ts
+++ b/apps/docs/components/composite-keyboard.ts
@@ -1,0 +1,36 @@
+export type CompositeDirection = 'previous' | 'next' | 'first' | 'last';
+
+function indexInDirection(
+  direction: CompositeDirection | undefined,
+  current: number,
+  count: number
+): number | undefined {
+  if (!direction || count < 1) return undefined;
+  if (direction === 'first') return 0;
+  if (direction === 'last') return count - 1;
+  return (current + (direction === 'next' ? 1 : -1) + count) % count;
+}
+
+/** Horizontal tablists use their visual axis, plus Home and End. */
+export function tabIndexForKey(key: string, current: number, count: number): number | undefined {
+  const direction: CompositeDirection | undefined = {
+    ArrowLeft: 'previous',
+    ArrowRight: 'next',
+    Home: 'first',
+    End: 'last',
+  }[key] as CompositeDirection | undefined;
+  return indexInDirection(direction, current, count);
+}
+
+/** Radio groups conventionally accept either arrow axis, plus Home and End. */
+export function radioIndexForKey(key: string, current: number, count: number): number | undefined {
+  const direction: CompositeDirection | undefined = {
+    ArrowLeft: 'previous',
+    ArrowUp: 'previous',
+    ArrowRight: 'next',
+    ArrowDown: 'next',
+    Home: 'first',
+    End: 'last',
+  }[key] as CompositeDirection | undefined;
+  return indexInDirection(direction, current, count);
+}

--- a/apps/docs/components/install-tabs.tsx
+++ b/apps/docs/components/install-tabs.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useCallback, useSyncExternalStore } from 'react';
+import { useCallback, useId, useRef, useSyncExternalStore } from 'react';
 import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock';
 import { cn } from '@/lib/utils';
+import { tabIndexForKey } from './composite-keyboard';
 
 /**
  * An install command, in the four package managers.
@@ -133,18 +134,43 @@ export interface InstallTabsProps {
 export function InstallTabs({ kind = 'expo', packages }: InstallTabsProps): React.ReactElement {
   const manager = useSyncExternalStore(subscribe, read, readServer);
   const onSelect = useCallback((next: PackageManager) => select(next), []);
-  const command = commandFor(manager, kind, packages);
+  const instanceId = useId();
+  const tabRefs = useRef<Partial<Record<PackageManager, HTMLButtonElement | null>>>({});
+
+  const onTabKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, name: PackageManager) => {
+      const nextIndex = tabIndexForKey(event.key, MANAGERS.indexOf(name), MANAGERS.length);
+      if (nextIndex === undefined) return;
+      event.preventDefault();
+      const next = MANAGERS[nextIndex];
+      onSelect(next);
+      tabRefs.current[next]?.focus();
+    },
+    [onSelect]
+  );
 
   return (
     <div className="not-prose my-4 overflow-hidden rounded-xl border bg-card">
-      <div role="tablist" aria-label="Package manager" className="flex flex-row border-b bg-muted/40">
+      <div
+        role="tablist"
+        aria-label="Package manager"
+        aria-orientation="horizontal"
+        className="flex flex-row border-b bg-muted/40"
+      >
         {MANAGERS.map((name) => (
           <button
             key={name}
+            ref={(node) => {
+              tabRefs.current[name] = node;
+            }}
             type="button"
             role="tab"
+            id={`${instanceId}-tab-${name}`}
+            aria-controls={`${instanceId}-panel-${name}`}
             aria-selected={manager === name}
+            tabIndex={manager === name ? 0 : -1}
             onClick={() => onSelect(name)}
+            onKeyDown={(event) => onTabKeyDown(event, name)}
             className={cn(
               'cursor-pointer border-b-2 px-4 py-2 font-mono text-sm transition-colors',
               manager === name
@@ -169,11 +195,25 @@ export function InstallTabs({ kind = 'expo', packages }: InstallTabsProps): Reac
        * colour rule pointing at a variable that only exists on highlighted
        * output.
        */}
-      <CodeBlock key={command} allowCopy className="m-0 rounded-none border-0">
-        <Pre>
-          <code className="px-4">{command}</code>
-        </Pre>
-      </CodeBlock>
+      {MANAGERS.map((name) => {
+        const command = commandFor(name, kind, packages);
+        return (
+          <div
+            key={name}
+            role="tabpanel"
+            id={`${instanceId}-panel-${name}`}
+            aria-labelledby={`${instanceId}-tab-${name}`}
+            hidden={manager !== name}
+            tabIndex={0}
+          >
+            <CodeBlock key={command} allowCopy className="m-0 rounded-none border-0">
+              <Pre>
+                <code className="px-4">{command}</code>
+              </Pre>
+            </CodeBlock>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/docs/components/showcase/themer.tsx
+++ b/apps/docs/components/showcase/themer.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useTheme } from 'next-themes';
 import { MoonIcon, SunIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { radioIndexForKey } from '../composite-keyboard';
 
 /**
  * The theme picker over the home page's component previews, and the element
@@ -52,6 +53,20 @@ function themeName(family: Family, mode: Mode): string {
 export function Themer({ children }: { children: ReactNode }): React.ReactElement {
   const [family, setFamily] = useState<Family>('panel');
   const { resolvedTheme, setTheme } = useTheme();
+  const familyRefs = useRef<Partial<Record<Family, HTMLButtonElement | null>>>({});
+
+  const onFamilyKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, id: Family) => {
+      const current = FAMILIES.findIndex((family) => family.id === id);
+      const nextIndex = radioIndexForKey(event.key, current, FAMILIES.length);
+      if (nextIndex === undefined) return;
+      event.preventDefault();
+      const next = FAMILIES[nextIndex].id;
+      setFamily(next);
+      familyRefs.current[next]?.focus();
+    },
+    []
+  );
 
   /*
    * `resolvedTheme` is undefined until the provider has read the stored choice
@@ -77,10 +92,16 @@ export function Themer({ children }: { children: ReactNode }): React.ReactElemen
           {FAMILIES.map(({ id, name, swatch }) => (
             <button
               key={id}
+              ref={(node) => {
+                familyRefs.current[id] = node;
+              }}
               type="button"
               role="radio"
+              aria-label={name}
               aria-checked={family === id}
+              tabIndex={family === id ? 0 : -1}
               onClick={() => setFamily(id)}
+              onKeyDown={(event) => onFamilyKeyDown(event, id)}
               className={cn(
                 'flex cursor-pointer items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition-colors',
                 family === id

--- a/apps/docs/test/composite-keyboard.test.mjs
+++ b/apps/docs/test/composite-keyboard.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  radioIndexForKey,
+  tabIndexForKey,
+} from '../components/composite-keyboard.ts';
+
+test('horizontal tabs wrap and support Home and End without consuming vertical keys', () => {
+  assert.equal(tabIndexForKey('ArrowRight', 3, 4), 0);
+  assert.equal(tabIndexForKey('ArrowLeft', 0, 4), 3);
+  assert.equal(tabIndexForKey('Home', 2, 4), 0);
+  assert.equal(tabIndexForKey('End', 1, 4), 3);
+  assert.equal(tabIndexForKey('ArrowDown', 1, 4), undefined);
+  assert.equal(tabIndexForKey('Enter', 1, 4), undefined);
+});
+
+test('radio groups wrap on either arrow axis and support Home and End', () => {
+  assert.equal(radioIndexForKey('ArrowRight', 2, 3), 0);
+  assert.equal(radioIndexForKey('ArrowDown', 2, 3), 0);
+  assert.equal(radioIndexForKey('ArrowLeft', 0, 3), 2);
+  assert.equal(radioIndexForKey('ArrowUp', 0, 3), 2);
+  assert.equal(radioIndexForKey('Home', 2, 3), 0);
+  assert.equal(radioIndexForKey('End', 0, 3), 2);
+  assert.equal(radioIndexForKey(' ', 1, 3), undefined);
+});
+
+test('InstallTabs links one roving tab to each hidden-capable panel', () => {
+  const source = fs.readFileSync(
+    fileURLToPath(new URL('../components/install-tabs.tsx', import.meta.url)),
+    'utf8'
+  );
+  assert.match(source, /role="tablist"[\s\S]*aria-orientation="horizontal"/);
+  assert.match(source, /aria-controls=\{`\$\{instanceId\}-panel-\$\{name\}`\}/);
+  assert.match(source, /tabIndex=\{manager === name \? 0 : -1\}/);
+  assert.match(source, /role="tabpanel"/);
+  assert.match(source, /aria-labelledby=\{`\$\{instanceId\}-tab-\$\{name\}`\}/);
+  assert.match(source, /hidden=\{manager !== name\}/);
+});
+
+test('Themer exposes named, checked radios with selected-item roving focus', () => {
+  const source = fs.readFileSync(
+    fileURLToPath(new URL('../components/showcase/themer.tsx', import.meta.url)),
+    'utf8'
+  );
+  assert.match(source, /role="radiogroup"[\s\S]*aria-label="Theme family"/);
+  assert.match(source, /role="radio"[\s\S]*aria-label=\{name\}/);
+  assert.match(source, /aria-checked=\{family === id\}/);
+  assert.match(source, /tabIndex=\{family === id \? 0 : -1\}/);
+  assert.match(source, /familyRefs\.current\[next\]\?\.focus\(\)/);
+});


### PR DESCRIPTION
## Summary
- add roving focus and wrapping ArrowLeft/ArrowRight/Home/End navigation to package-manager tabs
- connect SSR-stable tab and panel IDs with aria-controls and aria-labelledby
- keep inactive panels mounted with hidden semantics
- add roving focus plus four-direction/Home/End selection to the theme radio group
- preserve persisted package-manager and next-themes behavior

## Why
Both widgets declared composite ARIA roles but left every child in ordinary tab order and omitted the keyboard interaction model. InstallTabs also lacked valid tab-to-panel relationships.

## Validation
- focused keyboard contracts — 4/4 passed
- full docs suite — 6/6 passed
- docs typecheck — passed
- Next production build — passed (297 static pages)
- production docs asset generation — passed with no tracked diff
- git diff check — passed

A browser and assistive-technology smoke test remains recommended for announcement order.