### PR TITLE
docs(cli): document MCP commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -50,6 +50,51 @@ Everything available, grouped.
 npx panelui-cli@latest list
 ```
 
+### `mcp`
+
+Runs PanelUI's [Model Context Protocol](https://modelcontextprotocol.io/) server. An MCP client can
+inspect the registry, read component source and documentation, get the matching `add` command, and
+check how the current project consumes PanelUI.
+
+```bash
+npx panelui-cli@latest mcp
+```
+
+The server is a long-running stdio process intended to be launched by an MCP client. Standard input
+and output carry newline-delimited JSON-RPC messages; stdout contains no banner or other human-readable
+output. It reads project information from `--cwd` (the current directory by default).
+
+Registry lookups use `--registry <url>` first, then the registry in that project's `panelui.json`,
+then `https://panelui.dev/r`.
+
+#### `mcp init [claude|cursor|vscode]`
+
+Adds the server to a supported editor's project-level MCP configuration. The editor defaults to
+Claude Code when omitted.
+
+| Editor | Command | Config path, relative to `--cwd` |
+| --- | --- | --- |
+| Claude Code | `mcp init claude` | `.mcp.json` |
+| Cursor | `mcp init cursor` | `.cursor/mcp.json` |
+| VS Code | `mcp init vscode` | `.vscode/mcp.json` |
+
+```bash
+npx panelui-cli@latest mcp init
+npx panelui-cli@latest mcp init cursor
+npx panelui-cli@latest --cwd ./apps/mobile mcp init vscode
+```
+
+The command creates the parent directory when needed and merges a `panelui` server into the existing
+JSON instead of replacing other settings or servers. Claude Code and Cursor use the `mcpServers` map;
+VS Code uses `servers`. An existing `panelui` entry is updated to run:
+
+```text
+npx -y panelui-cli@latest mcp
+```
+
+The generated entry does not store one-off CLI options. To pin a registry or working directory for
+editor-launched sessions, add `--registry <url>` or `--cwd <dir>` to that server's generated `args`.
+
 ## Options
 
 | Flag | Effect |

--- a/packages/cli/test/readme-help-parity.test.mjs
+++ b/packages/cli/test/readme-help-parity.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const cli = fileURLToPath(new URL('../bin/panelui.mjs', import.meta.url));
+const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+
+function topLevelCommands(help) {
+  const section = help.match(/\nCommands\n(?<commands>[\s\S]*?)\n\n\S/);
+  assert.ok(section?.groups?.commands, 'CLI help must contain a Commands section');
+
+  return [
+    ...new Set(
+      section.groups.commands
+        .split('\n')
+        .map((line) => line.match(/^  (?<command>[a-z][\w-]*)\b/)?.groups?.command)
+        .filter(Boolean)
+    ),
+  ];
+}
+
+test('README keeps a command section for every command shipped in top-level help', () => {
+  const result = spawnSync(process.execPath, [cli, '--help'], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const commands = topLevelCommands(result.stdout);
+  assert.ok(commands.length > 0, 'top-level help must expose at least one command');
+
+  for (const command of commands) {
+    assert.match(readme, new RegExp('^### `' + command + '(?:\\s[^`]*)?`$', 'm'), command);
+  }
+});


### PR DESCRIPTION
## Summary
- document the shipped mcp stdio server and registry precedence
- document mcp init for Claude Code, Cursor, and VS Code
- describe generated config paths, merge behavior, map keys, and examples
- add an executable-help-derived top-level command parity regression

## Why
The package shipped MCP commands that were absent from its README, making the server and editor setup effectively undiscoverable.

## Validation
- focused README/help parity — 1/1 passed
- full CLI suite — 31/31 passed
- root typecheck and build — passed
- panelui-cli package dry-run — passed and includes README.md
- all-editor merge/config smoke — passed
- MCP stdio initialize smoke — passed with protocol-only stdout
- git diff check — passed