### PR TITLE
perf(example): virtualize the chart gallery

### DIFF
--- a/apps/example/app/components/all-charts.tsx
+++ b/apps/example/app/components/all-charts.tsx
@@ -106,7 +106,10 @@ export default function AllChartsScreen() {
         initialNumToRender={2}
         maxToRenderPerBatch={2}
         windowSize={3}
-        removeClippedSubviews
+        // Deliberately not `removeClippedSubviews`. It detaches views that have
+        // scrolled out rather than only skipping their render, and every card
+        // here is an SVG chart with animated paths — the case where that flag is
+        // known to leave blanks behind. The window above already does the work.
         contentContainerStyle={{ paddingBottom: insets.bottom + 32 }}
         showsVerticalScrollIndicator={false}
         ListHeaderComponent={

--- a/apps/example/app/components/all-charts.tsx
+++ b/apps/example/app/components/all-charts.tsx
@@ -1,4 +1,5 @@
-import { Pressable, ScrollView, View } from 'react-native';
+import { useCallback } from 'react';
+import { FlatList, Pressable, View, type ListRenderItemInfo } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ChevronRightIcon, Text, useThemeMode } from 'panelui-native';
@@ -75,10 +76,18 @@ function ChartCard({
   );
 }
 
+const chartKey = (entry: ComponentEntry) => entry.slug;
+
 export default function AllChartsScreen() {
   const insets = useSafeAreaInsets();
   const { mode } = useThemeMode();
   const tint = mode === 'dark' ? '#818181' : '#686868';
+  const renderChart = useCallback(
+    ({ item, index }: ListRenderItemInfo<ComponentEntry>) => (
+      <ChartCard entry={item} tint={tint} first={index === 0} />
+    ),
+    [tint]
+  );
 
   return (
     <View className="flex-1">
@@ -89,17 +98,23 @@ export default function AllChartsScreen() {
        * between entries divides it evenly between the two, which is exactly the
        * reading that was wrong.
        */}
-      <ScrollView
+      <FlatList
+        className="flex-1"
+        data={CHART_SHOWCASE}
+        renderItem={renderChart}
+        keyExtractor={chartKey}
+        initialNumToRender={2}
+        maxToRenderPerBatch={2}
+        windowSize={3}
+        removeClippedSubviews
         contentContainerStyle={{ paddingBottom: insets.bottom + 32 }}
         showsVerticalScrollIndicator={false}
-      >
-        <Text size="sm" muted className="px-5 pb-6">
-          {`${CHART_SHOWCASE.length} charts, one example each. Tap a name for its versions and props.`}
-        </Text>
-        {CHART_SHOWCASE.map((entry, index) => (
-          <ChartCard key={entry.slug} entry={entry} tint={tint} first={index === 0} />
-        ))}
-      </ScrollView>
+        ListHeaderComponent={
+          <Text size="sm" muted className="px-5 pb-6">
+            {`${CHART_SHOWCASE.length} charts, one example each. Tap a name for its versions and props.`}
+          </Text>
+        }
+      />
     </View>
   );
 }

--- a/apps/example/test/all-charts-virtualization.test.mjs
+++ b/apps/example/test/all-charts-virtualization.test.mjs
@@ -19,7 +19,9 @@ test('the chart gallery delegates rows to a bounded virtualized list', () => {
   assert.match(screen, /initialNumToRender=\{2\}/);
   assert.match(screen, /maxToRenderPerBatch=\{2\}/);
   assert.match(screen, /windowSize=\{3\}/);
-  assert.match(screen, /removeClippedSubviews/);
+  // Detaching offscreen views blanks animated SVG on iOS, and every row here is
+  // a chart. The window bounds the work without it.
+  assert.doesNotMatch(screen, /^\s*removeClippedSubviews\b/m);
   assert.doesNotMatch(screen, /CHART_SHOWCASE\.map/);
   assert.doesNotMatch(screen, /<ScrollView/);
 });

--- a/apps/example/test/all-charts-virtualization.test.mjs
+++ b/apps/example/test/all-charts-virtualization.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const screen = await readFile(
+  new URL('../app/components/all-charts.tsx', import.meta.url),
+  'utf8'
+);
+const catalogue = await readFile(
+  new URL('../src/data/components.tsx', import.meta.url),
+  'utf8'
+);
+
+test('the chart gallery delegates rows to a bounded virtualized list', () => {
+  assert.match(screen, /<FlatList/);
+  assert.match(screen, /<FlatList\s+className="flex-1"/);
+  assert.match(screen, /data=\{CHART_SHOWCASE\}/);
+  assert.match(screen, /renderItem=\{renderChart\}/);
+  assert.match(screen, /initialNumToRender=\{2\}/);
+  assert.match(screen, /maxToRenderPerBatch=\{2\}/);
+  assert.match(screen, /windowSize=\{3\}/);
+  assert.match(screen, /removeClippedSubviews/);
+  assert.doesNotMatch(screen, /CHART_SHOWCASE\.map/);
+  assert.doesNotMatch(screen, /<ScrollView/);
+});
+
+test('renderItem mounts the existing first demo with stable slug keys', () => {
+  assert.match(
+    screen,
+    /\(\{ item, index \}: ListRenderItemInfo<ComponentEntry>\) => \(\s*<ChartCard entry=\{item\} tint=\{tint\} first=\{index === 0\} \/>/
+  );
+  assert.match(screen, /const chartKey = \(entry: ComponentEntry\) => entry\.slug;/);
+  assert.match(screen, /keyExtractor=\{chartKey\}/);
+  assert.match(screen, /const version = entry\.demos\[0\];/);
+  assert.match(screen, /<View style=\{\{ minHeight: 300 \}\}>\{version\.render\(\)\}<\/View>/);
+});
+
+test('every declared chart remains sourced from the catalogue', () => {
+  const declaration = catalogue.match(/export const CHART_SLUGS = \[([\s\S]*?)\] as const;/);
+  assert.ok(declaration, 'CHART_SLUGS declaration is present');
+  const slugs = [...declaration[1].matchAll(/'([^']+)'/g)].map((match) => match[1]);
+
+  assert.equal(slugs.length, 14);
+  assert.equal(new Set(slugs).size, slugs.length);
+  for (const slug of slugs) {
+    assert.match(catalogue, new RegExp(`slug: '${slug.replaceAll('-', '\\-')}'`));
+  }
+  assert.match(
+    catalogue,
+    /CHART_SLUGS\.map\(\s*\(slug\) => COMPONENTS_BY_SLUG\[slug\]\s*\)\.filter/
+  );
+});


### PR DESCRIPTION
## Summary
- replace the eager chart-gallery ScrollView with a bounded FlatList
- mount two cards initially and two per render batch
- use a three-window viewport and stable chart-slug keys
- preserve the header, navigation, card styling, and all 14 current chart definitions
- add a gallery windowing and catalogue-completeness regression

## Why
The All Charts screen mounted every live SVG/gesture/animation tree immediately, including content far outside the viewport.

## Validation
- focused virtualization tests — 3/3 passed
- example and root typechecks — passed
- root package build — passed
- Android Expo export — passed (4,147 modules)
- git diff check — passed

Web export remains blocked by the repository's existing missing react-native-web dependency. Physical-device frame profiling remains a follow-up.