### PR TITLE
fix(package): make published contents deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build library
         run: npm run build
 
+      - name: Verify package contents
+        run: npm run verify:package --workspace=panelui-native
+
       - name: Node tests
         run: |
           # Discovered rather than globbed, so a workspace that grows its first

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Build library
         run: npm run build
 
+      - name: Verify package contents
+        run: npm run verify:package --workspace=panelui-native
+
       # The only thing standing between a mistyped tag and a wrong version on
       # npm, which cannot be taken back — npm does not allow a version to be
       # republished, even after an unpublish.

--- a/packages/panelui/package.json
+++ b/packages/panelui/package.json
@@ -17,7 +17,8 @@
   },
   "files": [
     "src",
-    "lib",
+    "lib/module",
+    "lib/typescript",
     "theme.css",
     "README.md",
     "!**/__tests__",
@@ -25,10 +26,12 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "bob build",
+    "build": "npm run clean && bob build",
+    "prepack": "npm run build && npm run verify:package",
     "test": "node --experimental-strip-types --test test/*.test.mjs",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf lib"
+    "clean": "rm -rf lib",
+    "verify:package": "node scripts/verify-package.mjs"
   },
   "keywords": [
     "react-native",

--- a/packages/panelui/scripts/verify-package.mjs
+++ b/packages/panelui/scripts/verify-package.mjs
@@ -76,10 +76,26 @@ if (forbiddenFiles.length > 0) {
   );
 }
 
+/*
+ * Set to catch a mistake, not to police growth.
+ *
+ * What this is guarding against is a stray directory finding its way into
+ * `files` — a `node_modules`, a build cache, a folder of recordings. Those
+ * arrive orders of magnitude over the line, so the line does not need to be
+ * anywhere near the current size to catch them.
+ *
+ * It needs to be well clear of it, though, because this step also runs in
+ * `publish.yml`, after the tag exists. A budget that a few ordinary components
+ * can cross turns a release into a failure at the one moment there is nothing
+ * useful to do about it. At 106 components the package is 768 files and 2.1 MB
+ * packed, and each new component costs six or seven files — so this leaves room
+ * for roughly another sixty of them. Raise it when it is genuinely reached;
+ * that is a normal thing to do and not a signal that anything is wrong.
+ */
 const budgets = {
-  files: 850,
-  packedBytes: 2_500_000,
-  unpackedBytes: 9_000_000,
+  files: 1_200,
+  packedBytes: 4_000_000,
+  unpackedBytes: 14_000_000,
 };
 const exceededBudgets = [
   ["files", manifest.entryCount, budgets.files],

--- a/packages/panelui/scripts/verify-package.mjs
+++ b/packages/panelui/scripts/verify-package.mjs
@@ -1,0 +1,100 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const packageJson = JSON.parse(
+  readFileSync(resolve(packageRoot, "package.json"), "utf8"),
+);
+const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const [manifest] = JSON.parse(
+  execFileSync(npm, ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+    cwd: packageRoot,
+    encoding: "utf8",
+  }),
+);
+
+const files = new Set(manifest.files.map(({ path }) => path));
+const allowedFiles = new Set(["README.md", "package.json", "theme.css"]);
+const allowedDirectories = ["src/", "lib/module/", "lib/typescript/"];
+
+const unexpectedFiles = [...files].filter(
+  (path) =>
+    !allowedFiles.has(path) &&
+    !allowedDirectories.some((directory) => path.startsWith(directory)),
+);
+
+if (unexpectedFiles.length > 0) {
+  throw new Error(
+    `Package contains files outside the publish contract:\n${unexpectedFiles.join("\n")}`,
+  );
+}
+
+const collectTargets = (value) => {
+  if (typeof value === "string") return [value];
+  if (!value || typeof value !== "object") return [];
+  return Object.values(value).flatMap(collectTargets);
+};
+
+const requiredTargets = new Set(
+  [
+    packageJson.main,
+    packageJson.module,
+    packageJson.types,
+    packageJson["react-native"],
+    ...collectTargets(packageJson.exports),
+  ]
+    .filter(Boolean)
+    .map((path) => path.replace(/^\.\//, "")),
+);
+for (const asset of [
+  "README.md",
+  "theme.css",
+  "lib/module/index.js.map",
+  "lib/typescript/src/index.d.ts.map",
+]) {
+  requiredTargets.add(asset);
+}
+
+const missingTargets = [...requiredTargets].filter((path) => !files.has(path));
+if (missingTargets.length > 0) {
+  throw new Error(
+    `Package is missing declared entry points:\n${missingTargets.join("\n")}`,
+  );
+}
+
+const forbiddenFiles = [...files].filter(
+  (path) =>
+    path.includes("/__tests__/") ||
+    path.includes(".test.") ||
+    path.endsWith(".tsbuildinfo"),
+);
+if (forbiddenFiles.length > 0) {
+  throw new Error(
+    `Package contains development-only files:\n${forbiddenFiles.join("\n")}`,
+  );
+}
+
+const budgets = {
+  files: 850,
+  packedBytes: 2_500_000,
+  unpackedBytes: 9_000_000,
+};
+const exceededBudgets = [
+  ["files", manifest.entryCount, budgets.files],
+  ["packed bytes", manifest.size, budgets.packedBytes],
+  ["unpacked bytes", manifest.unpackedSize, budgets.unpackedBytes],
+].filter(([, actual, maximum]) => actual > maximum);
+
+if (exceededBudgets.length > 0) {
+  throw new Error(
+    `Package exceeds its size budget:\n${exceededBudgets
+      .map(([name, actual, maximum]) => `${name}: ${actual} > ${maximum}`)
+      .join("\n")}`,
+  );
+}
+
+console.log(
+  `Verified package: ${manifest.entryCount} files, ${manifest.size} packed bytes, ${manifest.unpackedSize} unpacked bytes.`,
+);


### PR DESCRIPTION
## Summary
- publish only explicit Bob module and TypeScript output roots instead of arbitrary lib contents
- clean the full lib directory before builds and prepack
- verify all export targets, allowed roots, maps, required files, and package budgets
- run package verification in CI and the publish workflow
- retain src because the React Native export points to source, plus maps for debugging

## Why
Bob cleaned only its target subdirectories. Stale files at the lib root survived rebuilds and silently changed published tarballs; a clean checkout could also pack without required JS/type outputs.

## Validation
- package tests — 33/33 passed
- root build and all workspace typechecks — passed
- verifier — passed
- clean and stale-injected pack SHA-256 — identical
- final package — 768 files, 2,108,852 packed bytes, 8,016,517 unpacked bytes
- git diff check — passed

Budgets intentionally allow modest growth while explicit roots and clean builds prevent stale leakage.