### PR TITLE
fix(docs): centralize layout prefetch policy

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -24,6 +24,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { CopyInstall } from '@/components/copy-install';
+import { LayoutLink } from '@/components/layout-link';
 import { Showcase } from '@/components/showcase';
 import { absoluteUrl, site } from '@/lib/site';
 import meta from '@/scripts/meta.json';
@@ -287,12 +288,12 @@ export default function HomePage() {
             </p>
           </div>
           <nav className="flex gap-6" aria-label="Footer">
-            <Link href="/docs" prefetch={false} className="hover:text-foreground">
+            <LayoutLink href="/docs" className="hover:text-foreground">
               Documentation
-            </Link>
-            <Link href="/docs/components" prefetch={false} className="hover:text-foreground">
+            </LayoutLink>
+            <LayoutLink href="/docs/components" className="hover:text-foreground">
               Components
-            </Link>
+            </LayoutLink>
             <Link href={site.npm} className="hover:text-foreground">
               npm
             </Link>

--- a/apps/docs/components/layout-link-policy.ts
+++ b/apps/docs/components/layout-link-policy.ts
@@ -1,0 +1,10 @@
+/** Routes rendered more than once by the persistent navigation and footer. */
+export const REPEATED_LAYOUT_ROUTES = new Set(['/', '/docs', '/docs/components']);
+
+/** Keep explicit choices; otherwise suppress only repeated layout destinations. */
+export function layoutLinkPrefetch(
+  href: string,
+  prefetch?: boolean | null
+): boolean | null {
+  return prefetch ?? (REPEATED_LAYOUT_ROUTES.has(href) ? false : null);
+}

--- a/apps/docs/components/layout-link.tsx
+++ b/apps/docs/components/layout-link.tsx
@@ -2,21 +2,18 @@
 
 import Link from 'next/link';
 import type { ComponentPropsWithRef } from 'react';
+import { layoutLinkPrefetch } from '@/components/layout-link-policy';
 
 /**
  * Routes repeated by the persistent Fumadocs chrome.
  *
  * The desktop navbar, mobile menu and CTA can all contain the same destination,
  * so viewport prefetching each copy spends several RSC requests on one route.
- * Content links use `next/link` directly and keep its normal prefetching; this
- * policy applies only to links Fumadocs creates for its shared layouts.
+ * Content links use `next/link` directly and keep its normal prefetching. This
+ * wrapper owns links in Fumadocs' shared layouts and the repeated home footer.
  */
-const REPEATED_CHROME_ROUTES = new Set(['/', '/docs', '/docs/components']);
-
-type LayoutLinkProps = ComponentPropsWithRef<'a'> & { prefetch?: boolean };
+type LayoutLinkProps = ComponentPropsWithRef<'a'> & { prefetch?: boolean | null };
 
 export function LayoutLink({ href = '#', prefetch, ...props }: LayoutLinkProps) {
-  const repeated = REPEATED_CHROME_ROUTES.has(href);
-
-  return <Link href={href} prefetch={prefetch ?? (repeated ? false : null)} {...props} />;
+  return <Link href={href} prefetch={layoutLinkPrefetch(href, prefetch)} {...props} />;
 }

--- a/apps/docs/test/prefetch-policy.test.mjs
+++ b/apps/docs/test/prefetch-policy.test.mjs
@@ -3,31 +3,55 @@ import fs from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import {
+  layoutLinkPrefetch,
+  REPEATED_LAYOUT_ROUTES,
+} from '../components/layout-link-policy.ts';
 
 const docs = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const read = (file) => fs.readFileSync(path.join(docs, file), 'utf8');
 
-test('persistent layout chrome does not prefetch its repeated destinations', () => {
-  const layoutLink = read('components/layout-link.tsx');
-  const rootLayout = read('app/layout.tsx');
+test('layout prefetch policy covers every repeated route and preserves overrides', () => {
+  assert.deepEqual([...REPEATED_LAYOUT_ROUTES], ['/', '/docs', '/docs/components']);
 
-  assert.match(
-    layoutLink,
-    /REPEATED_CHROME_ROUTES = new Set\(\['\/', '\/docs', '\/docs\/components'\]\)/
-  );
-  assert.match(layoutLink, /repeated \? false : null/);
-  assert.match(rootLayout, /<RootProvider components=\{\{ Link: LayoutLink \}\}>/);
+  for (const href of REPEATED_LAYOUT_ROUTES) {
+    assert.equal(layoutLinkPrefetch(href), false, href);
+    assert.equal(layoutLinkPrefetch(href, true), true, `${href} explicit true`);
+  }
+
+  assert.equal(layoutLinkPrefetch('/docs/installation'), null);
+  assert.equal(layoutLinkPrefetch('https://github.com/panel-ui/PanelUI'), null);
+  assert.equal(layoutLinkPrefetch('/docs/installation', false), false);
 });
 
-test('footer copies opt out while primary content navigation keeps prefetching', () => {
+test('every repeated layout instance uses the shared policy', () => {
+  const instances = [
+    ['brand title', 'app/layout.config.tsx', "url: '/'"],
+    ['Docs navigation', 'app/layout.config.tsx', "text: 'Docs', url: '/docs'"],
+    ['Components navigation', 'app/layout.config.tsx', "url: '/docs/components'"],
+    [
+      'Get started navigation',
+      'app/layout.config.tsx',
+      "text: 'Get started',\n      url: '/docs'",
+    ],
+    ['Docs footer', 'app/(home)/page.tsx', '<LayoutLink href="/docs"'],
+    ['Components footer', 'app/(home)/page.tsx', '<LayoutLink href="/docs/components"'],
+  ];
+
+  for (const [name, file, source] of instances) {
+    assert.ok(read(file).includes(source), `${name} must remain covered`);
+  }
+
+  assert.match(read('app/layout.tsx'), /components=\{\{ Link: LayoutLink \}\}/);
+});
+
+test('primary content links keep Next prefetch and link behavior passes through', () => {
   const home = read('app/(home)/page.tsx');
   const showcase = read('components/showcase/index.tsx');
+  const layoutLink = read('components/layout-link.tsx');
 
-  assert.match(home, /href="\/docs" prefetch=\{false\} className="hover:text-foreground"/);
-  assert.match(
-    home,
-    /href="\/docs\/components" prefetch=\{false\} className="hover:text-foreground"/
-  );
   assert.match(home, /<Button render=\{<Link href="\/docs" \/>\}>/);
   assert.match(showcase, /render=\{<Link href="\/docs\/components" \/>\}/);
+  assert.match(home, /<Link href=\{site\.repo\}/);
+  assert.match(layoutLink, /prefetch=\{layoutLinkPrefetch\(href, prefetch\)\} \{\.\.\.props\}/);
 });


### PR DESCRIPTION
## Summary
- centralize repeated-layout route prefetch decisions in one pure policy
- route the home footer's repeated internal destinations through LayoutLink
- preserve explicit prefetch overrides and Next's default behavior for non-repeated routes
- inventory all six persistent copies in deterministic tests
- keep primary content links and external footer links unchanged

## Why
The original duplicate-prefetch fix is already on main, but its policy remained split between a hard-coded LayoutLink set, manual footer flags, and source-spelling tests. This follow-up makes the contract single-source and testable.

## Validation
- docs tests — 3/3 passed
- docs typecheck — passed
- Next production build — passed (297 static pages)
- prebuild asset generation — passed with no tracked diff
- production server smoke for / and /docs — passed with no repeated-route RSC prefetch/preload hints in initial HTML
- git diff check — passed

Initial-HTML validation does not replace a browser viewport network trace; later interaction prefetches and explicit caller overrides remain intentional.