### PR TITLE
feat(cli): add read-only doctor

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -76,6 +76,21 @@ npx panelui-cli@latest list --search "scroll progress" --json
 Current registries also expose `kind`, documentation `group`, and `stability` (`stable`, `beta` or
 `alpha`). Older custom indexes containing only `name`, `type` and `description` remain supported.
 
+### `doctor`
+
+Audits the current project without writing files or installing packages. It checks the PanelUI
+configuration and contained paths, aliases, CSS imports and sources, exported Metro wrapper, theme,
+Uniwind ambient types, required dependencies, and statically visible `PanelUIProvider` wiring.
+
+```bash
+npx panelui-cli@latest doctor
+npx panelui-cli@latest --cwd ./apps/mobile doctor --json
+```
+
+The human report marks confirmed errors with `✗`, warnings with `!`, and checks that need manual
+review with `?`. Confirmed errors exit with status 1; healthy, warning, and unknown-only reports exit
+with status 0. `--json` returns a versioned object with `status`, counts, and ordered `checks` for CI.
+
 ### `mcp`
 
 Runs PanelUI's [Model Context Protocol](https://modelcontextprotocol.io/) server. An MCP client can
@@ -133,7 +148,7 @@ editor-launched sessions, add `--registry <url>` or `--cwd <dir>` to that server
 | `--registry <url>` | Use a different registry |
 | `--type <kind>` | Filter list results: `ui`, `chart`, `hook`, `lib` or `theme` |
 | `--search <text>` | Rank list results matching every search term |
-| `--json` | Print list results as stable JSON |
+| `--json` | Print `list` or `doctor` results as stable JSON |
 
 A value-taking flag without its value prints its usage and exits with status 1. No command runs.
 

--- a/packages/cli/bin/panelui.mjs
+++ b/packages/cli/bin/panelui.mjs
@@ -7,6 +7,7 @@
  */
 import process from 'node:process';
 import { add, list } from '../src/add.mjs';
+import { diagnose, formatDoctor } from '../src/doctor.mjs';
 import { init } from '../src/init.mjs';
 import { mcp, mcpInit } from '../src/mcp.mjs';
 import { update } from '../src/update.mjs';
@@ -24,6 +25,7 @@ ${bold('Commands')}
   add <name...>        Copy components in, with everything they depend on
   update [name...]     Safely update unchanged installed component files
   list                 Discover registry items; filter with --type or --search
+  doctor               Check project setup without changing it
   mcp                  Run the MCP server, so an agent can read the registry
   mcp init [editor]    Write the server into an editor's config
                        claude | cursor | vscode
@@ -37,7 +39,7 @@ ${bold('Options')}
   --registry <url>     Use a different registry
   --type <kind>        ui | chart | hook | lib | theme
   --search <text>      Rank registry items matching every search term
-  --json               Print list results as stable JSON
+  --json               Print list or doctor results as stable JSON
   --help, -h           This
   --version, -v        Print the version
 
@@ -72,6 +74,7 @@ function parseArgs(argv) {
     theme: undefined,
     help: false,
     version: false,
+    json: false,
   };
   const positionals = [];
 
@@ -99,6 +102,9 @@ function parseArgs(argv) {
       case '--version':
       case '-v':
         options.version = true;
+        break;
+      case '--json':
+        options.json = true;
         break;
       case '--cwd':
         options.cwd = optionValue(argv, i, arg, '<dir>');
@@ -172,6 +178,12 @@ async function main() {
     case 'ls':
       await list(options);
       break;
+    case 'doctor': {
+      const report = diagnose(options.cwd);
+      info(options.json ? JSON.stringify(report, null, 2) : formatDoctor(report));
+      if (report.errors) process.exitCode = 1;
+      break;
+    }
     case 'mcp':
       if (rest[0] === 'init') {
         const { file, label } = mcpInit(options, rest[1]);

--- a/packages/cli/src/doctor.mjs
+++ b/packages/cli/src/doctor.mjs
@@ -1,0 +1,203 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  CANONICAL_ALIASES,
+  aliasToDir,
+  projectPath,
+  validateConfigPaths,
+} from "./config.mjs";
+import { BASE_DEPENDENCIES } from "./init.mjs";
+import { hasWrappedMetroExport } from "./patch.mjs";
+
+const check = (id, status, message) => ({ id, status, message });
+const read = (file) => fs.readFileSync(file, "utf8");
+
+function sourceFiles(root) {
+  if (!fs.existsSync(root)) return [];
+  return fs.readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) return [];
+    const file = path.join(root, entry.name);
+    if (entry.isDirectory()) return sourceFiles(file);
+    return /\.[cm]?[jt]sx?$/.test(entry.name) ? [file] : [];
+  });
+}
+
+export function diagnose(cwd) {
+  const checks = [];
+  const configFile = path.join(cwd, "panelui.json");
+  let config;
+  try {
+    config = JSON.parse(read(configFile));
+    if (!config || Array.isArray(config) || typeof config !== "object")
+      throw new Error("not an object");
+    if (config.registry !== undefined && typeof config.registry !== "string")
+      throw new Error("registry must be a string");
+    if (
+      config.aliases !== undefined &&
+      (!config.aliases ||
+        Array.isArray(config.aliases) ||
+        typeof config.aliases !== "object")
+    )
+      throw new Error("aliases must be an object");
+    validateConfigPaths(config);
+    checks.push(check("config", "ok", "panelui.json is valid and contained"));
+  } catch (error) {
+    const message = fs.existsSync(configFile)
+      ? error.message
+      : "panelui.json is missing";
+    checks.push(check("config", "error", message));
+    return report(cwd, checks);
+  }
+
+  const aliases = { ...CANONICAL_ALIASES, ...(config.aliases ?? {}) };
+  checks.push(check("aliases", "ok", Object.values(aliases).join(", ")));
+
+  const cssFile = projectPath(cwd, config.css ?? "global.css", "CSS path");
+  if (!fs.existsSync(cssFile)) {
+    checks.push(
+      check("css", "error", `${path.relative(cwd, cssFile)} is missing`),
+    );
+  } else {
+    const css = read(cssFile);
+    const cssDir = path.dirname(cssFile);
+    const required = ["@import 'tailwindcss'", "@import 'uniwind'"];
+    let themeImport = path
+      .relative(cssDir, path.join(cwd, config.theme ?? "theme.css"))
+      .split(path.sep)
+      .join("/");
+    if (!themeImport.startsWith(".")) themeImport = `./${themeImport}`;
+    required.push(`@import '${themeImport}'`);
+    const sourceDirs = new Set(
+      Object.values(aliases)
+        .map(aliasToDir)
+        .map((dir) => dir.split(/[\\/]/)[0]),
+    );
+    for (const dir of sourceDirs) {
+      let relative = path
+        .relative(cssDir, path.join(cwd, dir))
+        .split(path.sep)
+        .join("/");
+      if (!relative.startsWith(".")) relative = `./${relative}`;
+      required.push(`@source '${relative}'`);
+    }
+    const missing = required.filter((line) => !css.includes(line));
+    checks.push(
+      check(
+        "css",
+        missing.length ? "error" : "ok",
+        missing.length
+          ? `missing ${missing.join(", ")}`
+          : "imports and sources are present",
+      ),
+    );
+  }
+
+  const metroFile = ["metro.config.js", "metro.config.mjs", "metro.config.cjs"]
+    .map((file) => path.join(cwd, file))
+    .find(fs.existsSync);
+  checks.push(
+    !metroFile
+      ? check("metro", "error", "Metro config is missing")
+      : hasWrappedMetroExport(read(metroFile))
+        ? check("metro", "ok", "export wraps withUniwindConfig")
+        : check(
+            "metro",
+            "warning",
+            "could not prove the exported config uses withUniwindConfig",
+          ),
+  );
+
+  const themeFile = projectPath(cwd, config.theme ?? "theme.css", "Theme path");
+  checks.push(
+    check(
+      "theme",
+      fs.existsSync(themeFile) ? "ok" : "error",
+      fs.existsSync(themeFile)
+        ? "theme file is present"
+        : `${path.relative(cwd, themeFile)} is missing`,
+    ),
+  );
+
+  const typesFile = [
+    path.join(cwd, "uniwind-env.d.ts"),
+    ...sourceFiles(path.join(cwd, "src")),
+  ].find(
+    (file) =>
+      fs.existsSync(file) &&
+      /\.d\.ts$/.test(file) &&
+      /uniwind\/types/.test(read(file)),
+  );
+  checks.push(
+    check(
+      "types",
+      typesFile ? "ok" : "warning",
+      typesFile
+        ? "Uniwind ambient types are present"
+        : "could not find an ambient uniwind/types import",
+    ),
+  );
+
+  let manifest = {};
+  try {
+    manifest = JSON.parse(read(path.join(cwd, "package.json")));
+  } catch {}
+  const deps = { ...manifest.dependencies, ...manifest.devDependencies };
+  const missingDeps = BASE_DEPENDENCIES.filter((name) => !(name in deps));
+  checks.push(
+    check(
+      "dependencies",
+      missingDeps.length ? "error" : "ok",
+      missingDeps.length
+        ? `missing ${missingDeps.join(", ")}`
+        : "required packages are present",
+    ),
+  );
+
+  const appFiles = ["app", "src/app"].flatMap((dir) =>
+    sourceFiles(path.join(cwd, dir)),
+  );
+  const provider = appFiles.some((file) => {
+    const source = read(file);
+    return (
+      /import\s*\{[^}]*\bPanelUIProvider\b[^}]*\}\s*from\s*['"][^'"]+['"]/.test(
+        source,
+      ) && /<PanelUIProvider\b/.test(source)
+    );
+  });
+  checks.push(
+    check(
+      "provider",
+      provider ? "ok" : "unknown",
+      provider
+        ? "PanelUIProvider is wired in app source"
+        : "provider wiring needs manual review",
+    ),
+  );
+  return report(cwd, checks);
+}
+
+function report(cwd, checks) {
+  const errors = checks.filter((item) => item.status === "error").length;
+  const warnings = checks.filter(
+    (item) => item.status === "warning" || item.status === "unknown",
+  ).length;
+  return {
+    version: 1,
+    cwd: path.resolve(cwd),
+    status: errors ? "broken" : warnings ? "review" : "healthy",
+    errors,
+    warnings,
+    checks,
+  };
+}
+
+export function formatDoctor(report) {
+  const mark = { ok: "✓", error: "✗", warning: "!", unknown: "?" };
+  return [
+    `PanelUI doctor: ${report.status}`,
+    ...report.checks.map(
+      (item) => `${mark[item.status]} ${item.id}: ${item.message}`,
+    ),
+    `${report.errors} errors, ${report.warnings} warnings/unknowns`,
+  ].join("\n");
+}

--- a/packages/cli/src/init.mjs
+++ b/packages/cli/src/init.mjs
@@ -43,7 +43,7 @@ import {
 } from './ui.mjs';
 
 /** Needed by anything the registry can install. */
-const BASE_DEPENDENCIES = [
+export const BASE_DEPENDENCIES = [
   'uniwind',
   'tailwindcss',
   'tailwind-variants',

--- a/packages/cli/src/patch.mjs
+++ b/packages/cli/src/patch.mjs
@@ -150,7 +150,7 @@ function codeOnly(source) {
  * Existing Metro configs are never edited, so an unfamiliar but valid shape
  * gets safe manual instructions instead of a false claim that setup is done.
  */
-function hasWrappedMetroExport(source) {
+export function hasWrappedMetroExport(source) {
   const code = codeOnly(source);
   const wrapperCall = String.raw`(?:\(\s*)*withUniwindConfig\s*\(`;
   const directExports = [

--- a/packages/cli/test/doctor.test.mjs
+++ b/packages/cli/test/doctor.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { BASE_DEPENDENCIES } from "../src/init.mjs";
+
+const cli = fileURLToPath(new URL("../bin/panelui.mjs", import.meta.url));
+const temp = () => fs.mkdtempSync(path.join(os.tmpdir(), "panelui-doctor-"));
+const write = (root, file, value) => {
+  const target = path.join(root, file);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, value);
+};
+const run = (root, ...args) =>
+  spawnSync(process.execPath, [cli, "--cwd", root, "doctor", ...args], {
+    encoding: "utf8",
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+
+function fixture({ metro = "wrapped", provider = true } = {}) {
+  const root = temp();
+  write(
+    root,
+    "panelui.json",
+    JSON.stringify({
+      registry: "https://panelui.dev/r",
+      aliases: {
+        components: "@/components/ui",
+        lib: "@/lib",
+        hooks: "@/hooks",
+      },
+      css: "global.css",
+      theme: "theme.css",
+    }),
+  );
+  write(
+    root,
+    "package.json",
+    JSON.stringify({
+      dependencies: Object.fromEntries(
+        BASE_DEPENDENCIES.map((name) => [name, "*"]),
+      ),
+    }),
+  );
+  write(
+    root,
+    "global.css",
+    "@import 'tailwindcss';\n@import 'uniwind';\n@import './theme.css';\n@source './components';\n@source './lib';\n@source './hooks';\n",
+  );
+  write(root, "theme.css", ":root {}\n");
+  write(root, "uniwind-env.d.ts", "import 'uniwind/types';\n");
+  write(
+    root,
+    "metro.config.js",
+    metro === "wrapped"
+      ? "const { withUniwindConfig } = require('uniwind/metro');\nmodule.exports = withUniwindConfig({});\n"
+      : "const wrap = require('./wrap');\nmodule.exports = wrap({});\n",
+  );
+  if (provider)
+    write(
+      root,
+      "app/_layout.tsx",
+      "import { PanelUIProvider } from 'panelui-native';\nexport default () => <PanelUIProvider><Slot /></PanelUIProvider>;\n",
+    );
+  return root;
+}
+
+function snapshot(root) {
+  const hash = crypto.createHash("sha256");
+  for (const file of fs
+    .readdirSync(root, { recursive: true })
+    .filter((name) => fs.statSync(path.join(root, name)).isFile())
+    .sort()) {
+    hash.update(file);
+    hash.update(fs.readFileSync(path.join(root, file)));
+  }
+  return hash.digest("hex");
+}
+
+test("healthy project exits zero and doctor is strictly read-only", () => {
+  const root = fixture();
+  const before = snapshot(root);
+  const result = run(root);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /PanelUI doctor: healthy/);
+  assert.equal(snapshot(root), before);
+});
+
+test("confirmed breakage exits nonzero with stable machine-readable checks", () => {
+  const root = fixture();
+  write(root, "panelui.json", "{broken");
+  const first = run(root, "--json");
+  const second = run(root, "--json");
+  assert.equal(first.status, 1);
+  assert.equal(first.stdout, second.stdout);
+  const report = JSON.parse(first.stdout);
+  assert.deepEqual(Object.keys(report), [
+    "version",
+    "cwd",
+    "status",
+    "errors",
+    "warnings",
+    "checks",
+  ]);
+  assert.deepEqual(report.checks[0].id, "config");
+  assert.equal(report.status, "broken");
+});
+
+test("ambiguous static wiring requests review without claiming an error", () => {
+  const root = fixture({ metro: "ambiguous", provider: false });
+  const result = run(root, "--json");
+  const report = JSON.parse(result.stdout);
+  assert.equal(result.status, 0);
+  assert.equal(report.status, "review");
+  assert.deepEqual(
+    report.checks
+      .filter((item) => item.status !== "ok")
+      .map((item) => [item.id, item.status]),
+    [
+      ["metro", "warning"],
+      ["provider", "unknown"],
+    ],
+  );
+});
+
+test("unsafe configured paths are confirmed errors without escaping the project", () => {
+  const root = fixture();
+  write(
+    root,
+    "panelui.json",
+    JSON.stringify({ aliases: { components: "../../outside" } }),
+  );
+  const result = run(root, "--json");
+  assert.equal(result.status, 1);
+  assert.equal(JSON.parse(result.stdout).checks[0].id, "config");
+});


### PR DESCRIPTION
## Summary
- add a strictly read-only panelui doctor command with human and versioned JSON reports
- reuse existing path-containment, dependency, and exported-Metro-wrapper contracts
- diagnose config, aliases, CSS, Metro, theme, ambient types, dependencies, and statically visible provider wiring
- distinguish confirmed errors from warnings and unknown/manual-review states
- add end-to-end healthy, broken, ambiguous, containment, JSON-stability, and no-mutation fixtures
- document the command and keep README/help parity

## Why
PanelUI could initialize and add files but offered no safe way to explain a broken setup. Several configuration failures otherwise appear as missing styling or runtime errors far from their cause.

## Validation
- full CLI suite — 54/54 passed
- root typecheck and build — passed
- panelui-cli package dry-run — passed (12 files, including doctor and README)
- help/README parity — passed
- whole-fixture hash proves doctor does not mutate files
- git diff check — passed

Static analysis intentionally reports warning/unknown for provider indirection or unfamiliar Metro composition. It does not execute user configs or verify lockfile/node_modules version integrity.