### PR TITLE
feat(cli): add conflict-safe component updates

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,7 +13,7 @@ npx panelui-cli@latest add button
 | | `panelui-native` | `panelui-cli` |
 | --- | --- | --- |
 | You get | A dependency | Source files in your repo |
-| Updates | `npm update` | Re-run `add --overwrite`, or keep your edits |
+| Updates | `npm update` | `update` unchanged files; conflicts keep your edits |
 | Editing | Wrap or restyle it | Change the file |
 | Install size | Whole library | Only what you add |
 
@@ -42,6 +42,24 @@ packages required by those files.
 npx panelui-cli@latest add item message
 npx panelui-cli@latest add button --overwrite
 ```
+
+Successful writes are recorded in `panelui-lock.json`. `--overwrite` remains the explicit way to
+replace an existing file and makes that new copy eligible for later safe updates.
+
+### `update [name...]`
+
+Fetches tracked components again and updates only files whose digest still matches the copy the CLI
+installed. Locally edited or deleted files are reported as conflicts and never replaced. Omit names
+to update every tracked component. Files removed upstream are deleted only when still untouched.
+
+```bash
+npx panelui-cli@latest update
+npx panelui-cli@latest update button --check
+```
+
+`--check` and `--dry-run` never write and exit with status 1 when a safe update or conflict exists.
+Projects created before the lockfile are left untouched until an explicit `add <name> --overwrite`
+establishes the first trusted digest.
 
 ### `list [--type kind] [--search text] [--json]`
 
@@ -109,6 +127,7 @@ editor-launched sessions, add `--registry <url>` or `--cwd <dir>` to that server
 | --- | --- |
 | `--yes`, `-y` | Accept every prompt |
 | `--overwrite` | Replace files that already exist |
+| `--check` | Check tracked files for updates without writing |
 | `--dry-run` | Show what would happen, write nothing |
 | `--cwd <dir>` | Run against another directory |
 | `--registry <url>` | Use a different registry |
@@ -134,6 +153,9 @@ A value-taking flag without its value prints its usage and exits with status 1. 
 ```
 
 Change the aliases and imports are rewritten to match on the way in.
+
+`panelui-lock.json` records SHA-256 digests and registry ownership for files successfully copied by
+`add` or `update`. Commit it with the project so updates have the same safety baseline everywhere.
 
 ## Notes
 

--- a/packages/cli/bin/panelui.mjs
+++ b/packages/cli/bin/panelui.mjs
@@ -9,6 +9,7 @@ import process from 'node:process';
 import { add, list } from '../src/add.mjs';
 import { init } from '../src/init.mjs';
 import { mcp, mcpInit } from '../src/mcp.mjs';
+import { update } from '../src/update.mjs';
 import { CliError, bold, dim, error, info, optionValue } from '../src/ui.mjs';
 
 const HELP = `
@@ -21,6 +22,7 @@ ${bold('Commands')}
   init                 In an empty folder, start a new app from a template.
                        In an existing one, set it up to receive components.
   add <name...>        Copy components in, with everything they depend on
+  update [name...]     Safely update unchanged installed component files
   list                 Discover registry items; filter with --type or --search
   mcp                  Run the MCP server, so an agent can read the registry
   mcp init [editor]    Write the server into an editor's config
@@ -29,6 +31,7 @@ ${bold('Commands')}
 ${bold('Options')}
   --yes, -y            Accept every prompt
   --overwrite          Replace files that already exist
+  --check              Check for safe updates without writing
   --dry-run            Show what would happen, write nothing
   --cwd <dir>          Run against another directory
   --registry <url>     Use a different registry
@@ -48,6 +51,7 @@ ${bold('Examples')}
   npx panelui-cli@latest init --template starter --name my-app --theme moon
   npx panelui-cli@latest add button
   npx panelui-cli@latest add item message --yes
+  npx panelui-cli@latest update --check
   npx panelui-cli@latest list --type chart --search bar
   npx panelui-cli@latest mcp init cursor
 `;
@@ -57,6 +61,7 @@ function parseArgs(argv) {
     cwd: process.cwd(),
     assumeYes: false,
     overwrite: false,
+    check: false,
     dryRun: false,
     registry: undefined,
     type: undefined,
@@ -80,6 +85,9 @@ function parseArgs(argv) {
         break;
       case '--overwrite':
         options.overwrite = true;
+        break;
+      case '--check':
+        options.check = true;
         break;
       case '--dry-run':
         options.dryRun = true;
@@ -156,6 +164,9 @@ async function main() {
       break;
     case 'add':
       await add(rest, options);
+      break;
+    case 'update':
+      await update(rest, options);
       break;
     case 'list':
     case 'ls':

--- a/packages/cli/src/add.mjs
+++ b/packages/cli/src/add.mjs
@@ -7,6 +7,7 @@ import { applyAliases, detectProject, requireConfig, targetPath } from './config
 import { discover, kindOf } from './discovery.mjs';
 import { collectDependencies, fetchIndex, resolve } from './registry.mjs';
 import { installDependencies } from './patch.mjs';
+import { recordInstalled } from './lock.mjs';
 import { bold, confirm, dim, fail, info, step, success, warn } from './ui.mjs';
 
 export async function add(names, options) {
@@ -81,6 +82,7 @@ export async function add(names, options) {
       fs.mkdirSync(path.dirname(write.destination), { recursive: true });
       fs.writeFileSync(write.destination, write.content);
     }
+    recordInstalled(cwd, pending, registry);
     success(`Wrote ${pending.length} file${pending.length === 1 ? '' : 's'}`);
   } else {
     success('Component files are already installed.');

--- a/packages/cli/src/lock.mjs
+++ b/packages/cli/src/lock.mjs
@@ -1,0 +1,45 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { projectPath } from './config.mjs';
+
+export const LOCK_FILE = 'panelui-lock.json';
+
+export function digest(content) {
+  return `sha256:${createHash('sha256').update(content).digest('hex')}`;
+}
+
+export function readLock(cwd) {
+  const file = projectPath(cwd, LOCK_FILE, 'Lockfile path');
+  if (!fs.existsSync(file)) return null;
+  try {
+    const value = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (!value || value.version !== 1 || !value.files || Array.isArray(value.files)) return null;
+    return Object.values(value.files).every(
+      (entry) => typeof entry?.item === 'string' && /^sha256:[a-f0-9]{64}$/.test(entry.digest)
+    ) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function recordInstalled(cwd, writes, registry) {
+  const lock = readLock(cwd) ?? { version: 1, files: {} };
+  lock.registry = registry;
+  for (const write of writes) {
+    const relative = write.relative.split(path.sep).join('/');
+    lock.files[relative] = { item: write.item, digest: digest(write.content) };
+  }
+  writeLock(cwd, lock);
+}
+
+export function writeLock(cwd, lock) {
+  const file = projectPath(cwd, LOCK_FILE, 'Lockfile path');
+  const temporary = `${file}.${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(temporary, JSON.stringify(lock, null, 2) + '\n');
+    fs.renameSync(temporary, file);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}

--- a/packages/cli/src/update.mjs
+++ b/packages/cli/src/update.mjs
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { applyAliases, detectProject, projectPath, requireConfig, targetPath } from './config.mjs';
+import { digest, LOCK_FILE, readLock, writeLock } from './lock.mjs';
+import { collectDependencies, resolve } from './registry.mjs';
+import { installDependencies } from './patch.mjs';
+import { bold, confirm, dim, fail, info, success, warn } from './ui.mjs';
+
+export async function update(names, options) {
+  const cwd = options.cwd;
+  const config = requireConfig(cwd);
+  const lock = readLock(cwd);
+  if (!lock) {
+    fail(
+      `No usable ${LOCK_FILE} here, so existing files cannot be proven unchanged.`,
+      'Re-run `add <name> --overwrite` once for components you want the CLI to track.'
+    );
+  }
+
+  const installed = [...new Set(Object.values(lock.files).map((entry) => entry.item))];
+  const requested = names.length ? names : installed;
+  const unknown = requested.filter((name) => !installed.includes(name));
+  if (unknown.length) {
+    fail(`Not tracked as installed: ${unknown.join(', ')}.`, 'Use `add` for new components.');
+  }
+  if (!requested.length) fail(`No tracked components in ${LOCK_FILE}.`);
+
+  const registry = options.registry ?? config.registry;
+  const items = await resolve(registry, requested);
+  const candidates = [];
+  for (const item of items) {
+    for (const file of item.files) {
+      const destination = targetPath(cwd, config, file.path);
+      const relative = path.relative(cwd, destination).split(path.sep).join('/');
+      const content = applyAliases(file.content, config);
+      const tracked = lock.files[relative];
+      const current = fs.existsSync(destination) ? fs.readFileSync(destination, 'utf8') : null;
+      let status = 'update';
+      if (current === content) status = 'current';
+      else if (current === null) status = tracked ? 'conflict' : 'update';
+      else if (!tracked || digest(current) !== tracked.digest) status = 'conflict';
+      candidates.push({ item: item.name, destination, relative, content, status });
+    }
+  }
+
+  const incoming = new Set(candidates.map((file) => file.relative));
+  for (const [relative, tracked] of Object.entries(lock.files)) {
+    if (!requested.includes(tracked.item) || incoming.has(relative)) continue;
+    const destination = projectPath(cwd, relative, 'Tracked file path');
+    const current = fs.existsSync(destination) ? fs.readFileSync(destination, 'utf8') : null;
+    candidates.push({
+      item: tracked.item,
+      destination,
+      relative,
+      status: current !== null && digest(current) === tracked.digest ? 'remove' : 'conflict',
+    });
+  }
+
+  info('');
+  info(`Checking ${requested.map(bold).join(', ')}`);
+  info('');
+  for (const file of candidates) {
+    const marker = { current: '·', update: '~', remove: '-', conflict: '!' }[file.status];
+    const note = file.status === 'conflict' ? ' (modified)' : file.status === 'remove' ? ' (removed upstream)' : '';
+    info(`  ${marker} ${file.relative}${dim(note)}`);
+  }
+
+  const safe = candidates.filter((file) => file.status === 'update' || file.status === 'remove');
+  const conflicts = candidates.filter((file) => file.status === 'conflict');
+  const preview = options.check || options.dryRun;
+  const project = detectProject(cwd);
+  const { dependencies } = collectDependencies(items);
+  const missing = dependencies.filter((dependency) => !(dependency in project.deps));
+  if (missing.length) info(dim(`  + install ${missing.join(', ')}`));
+  if (conflicts.length) {
+    warn(`${conflicts.length} modified or untracked file${conflicts.length === 1 ? '' : 's'} left alone.`);
+  }
+
+  if (!preview && (safe.length || missing.length)) {
+    if (safe.length && !(await confirm(`Apply ${safe.length} file change${safe.length === 1 ? '' : 's'}?`, options))) {
+      info(dim('Cancelled.'));
+      return;
+    }
+    await installDependencies(cwd, missing, { ...options, isExpo: project.isExpo });
+    for (const file of safe) {
+      if (file.status === 'remove') fs.rmSync(file.destination);
+      else {
+        fs.mkdirSync(path.dirname(file.destination), { recursive: true });
+        fs.writeFileSync(file.destination, file.content);
+      }
+    }
+    if (safe.length) {
+      const nextLock = structuredClone(lock);
+      nextLock.registry = registry;
+      for (const file of candidates.filter((entry) => entry.status !== 'conflict')) {
+        if (file.status === 'remove') delete nextLock.files[file.relative];
+        else nextLock.files[file.relative] = { item: file.item, digest: digest(file.content) };
+      }
+      writeLock(cwd, nextLock);
+      success(`Applied ${safe.length} file change${safe.length === 1 ? '' : 's'}`);
+    }
+  } else if (!preview) {
+    if (!conflicts.length) success('Tracked component files are current.');
+  } else if (safe.length || missing.length) {
+    const count = safe.length + missing.length;
+    info(dim(`${count} safe update${count === 1 ? '' : 's'} available; nothing written.`));
+  } else if (!conflicts.length) {
+    success('Tracked component files are current.');
+  }
+
+  if ((preview && (safe.length || missing.length)) || conflicts.length) process.exitCode = 1;
+  info('');
+}

--- a/packages/cli/test/safe-update.test.mjs
+++ b/packages/cli/test/safe-update.test.mjs
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { after, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { writeLock } from '../src/lock.mjs';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-safe-update-'));
+after(() => fs.rmSync(root, { recursive: true, force: true }));
+const cli = fileURLToPath(new URL('../bin/panelui.mjs', import.meta.url));
+
+function waitForLine(stream) {
+  return new Promise((resolve) => {
+    let output = '';
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => {
+      output += chunk;
+      if (output.includes('\n')) resolve(output.split('\n')[0].trim());
+    });
+  });
+}
+
+function run(args, env = {}) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1', ...env },
+  });
+}
+
+test('update writes only digest-matching files and reports modified files', async () => {
+  const registry = path.join(root, 'registry');
+  const project = path.join(root, 'project');
+  fs.mkdirSync(registry);
+  fs.mkdirSync(project);
+  fs.writeFileSync(path.join(project, 'package.json'), JSON.stringify({ dependencies: {} }));
+  fs.writeFileSync(
+    path.join(project, 'panelui.json'),
+    JSON.stringify({
+      registry: 'https://panelui.dev/r',
+      aliases: { components: '@/components/ui', lib: '@/lib', hooks: '@/hooks' },
+    })
+  );
+
+  const writeRegistry = (first, second, extra = [], dependencies = [], registryDependencies = []) =>
+    fs.writeFileSync(
+      path.join(registry, 'card.json'),
+      JSON.stringify({
+        name: 'card',
+        files: [
+          { path: 'ui/card.tsx', content: first },
+          { path: 'ui/card-style.ts', content: second },
+          ...extra,
+        ],
+        dependencies,
+        registryDependencies,
+      })
+    );
+  writeRegistry('card v1\n', 'style v1\n', [{ path: 'ui/removed.ts', content: 'old\n' }]);
+
+  const server = spawn(
+    process.execPath,
+    [
+      '-e',
+      `const http=require('node:http'),fs=require('node:fs'),path=require('node:path');const root=process.argv[1];const server=http.createServer((req,res)=>{const file=path.join(root,req.url);if(!fs.existsSync(file)){res.writeHead(404).end();return}res.end(fs.readFileSync(file))});server.listen(0,'127.0.0.1',()=>console.log(server.address().port));`,
+      registry,
+    ],
+    { stdio: ['ignore', 'pipe', 'inherit'] }
+  );
+
+  try {
+    const port = await waitForLine(server.stdout);
+    const common = ['--cwd', project, '--registry', `http://127.0.0.1:${port}`, '--yes'];
+    const added = run(['add', 'card', ...common]);
+    assert.equal(added.status, 0, `${added.stdout}${added.stderr}`);
+    const lock = JSON.parse(fs.readFileSync(path.join(project, 'panelui-lock.json'), 'utf8'));
+    assert.equal(lock.version, 1);
+    assert.equal(lock.files['components/ui/card.tsx'].item, 'card');
+    const unchanged = run(['update', ...common]);
+    assert.equal(unchanged.status, 0, `${unchanged.stdout}${unchanged.stderr}`);
+
+    fs.writeFileSync(path.join(project, 'components/ui/card-style.ts'), 'local style\n');
+    fs.writeFileSync(
+      path.join(registry, 'helper.json'),
+      JSON.stringify({ name: 'helper', files: [{ path: 'lib/helper.ts', content: 'helper\n' }] })
+    );
+    writeRegistry('card v2\n', 'style v2\n', [], ['safe-update-fixture'], ['helper']);
+    const bin = path.join(root, 'bin');
+    const marker = path.join(root, 'installed');
+    fs.mkdirSync(bin);
+    fs.writeFileSync(path.join(bin, 'npm'), '#!/bin/sh\necho called >> "$PANELUI_MARKER"\n');
+    fs.chmodSync(path.join(bin, 'npm'), 0o755);
+    const installEnv = { PATH: `${bin}:${process.env.PATH}`, PANELUI_MARKER: marker };
+    const beforeCheck = fs.readFileSync(path.join(project, 'components/ui/card.tsx'), 'utf8');
+    const lockBeforeCheck = fs.readFileSync(path.join(project, 'panelui-lock.json'), 'utf8');
+    const checked = run(['update', '--check', ...common], installEnv);
+    assert.equal(checked.status, 1, `${checked.stdout}${checked.stderr}`);
+    assert.equal(fs.existsSync(marker), false);
+    assert.equal(fs.readFileSync(path.join(project, 'components/ui/card.tsx'), 'utf8'), beforeCheck);
+    assert.equal(fs.readFileSync(path.join(project, 'panelui-lock.json'), 'utf8'), lockBeforeCheck);
+    assert.equal(run(['update', '--dry-run', ...common], installEnv).status, 1);
+    assert.equal(fs.existsSync(marker), false);
+    assert.equal(fs.readFileSync(path.join(project, 'panelui-lock.json'), 'utf8'), lockBeforeCheck);
+
+    const updated = run(['update', ...common], installEnv);
+    const output = `${updated.stdout}${updated.stderr}`;
+    assert.equal(updated.status, 1, output);
+    assert.equal(fs.readFileSync(path.join(project, 'components/ui/card.tsx'), 'utf8'), 'card v2\n');
+    assert.equal(
+      fs.readFileSync(path.join(project, 'components/ui/card-style.ts'), 'utf8'),
+      'local style\n'
+    );
+    assert.match(output, /1 modified or untracked file left alone/);
+    assert.equal(fs.readFileSync(marker, 'utf8'), 'called\n');
+    assert.equal(fs.existsSync(path.join(project, 'components/ui/removed.ts')), false);
+    assert.equal(fs.readFileSync(path.join(project, 'lib/helper.ts'), 'utf8'), 'helper\n');
+
+    fs.writeFileSync(
+      path.join(registry, 'bad.json'),
+      JSON.stringify({ name: 'bad', files: [{ path: 'ui/bad.ts', content: 'safe\n' }] })
+    );
+    assert.equal(run(['add', 'bad', ...common]).status, 0);
+    fs.writeFileSync(
+      path.join(registry, 'bad.json'),
+      JSON.stringify({ name: 'bad', files: [{ path: '../escape.ts', content: 'nope\n' }] })
+    );
+    const traversal = run(['update', 'bad', ...common]);
+    assert.equal(traversal.status, 1);
+    assert.equal(fs.existsSync(path.join(project, '..', 'escape.ts')), false);
+  } finally {
+    server.kill();
+  }
+});
+
+test('lockfile replacement is atomic when rename is interrupted', () => {
+  const project = path.join(root, 'atomic');
+  fs.mkdirSync(project);
+  const file = path.join(project, 'panelui-lock.json');
+  fs.writeFileSync(file, '{"version":1,"files":{}}\n');
+  const rename = fs.renameSync;
+  fs.renameSync = () => {
+    throw new Error('interrupted');
+  };
+  try {
+    assert.throws(() => writeLock(project, { version: 1, files: { changed: {} } }), /interrupted/);
+  } finally {
+    fs.renameSync = rename;
+  }
+  assert.equal(fs.readFileSync(file, 'utf8'), '{"version":1,"files":{}}\n');
+  assert.deepEqual(fs.readdirSync(project), ['panelui-lock.json']);
+});
+
+test('legacy projects without digests are refused without touching files', () => {
+  const project = path.join(root, 'legacy');
+  fs.mkdirSync(project);
+  fs.writeFileSync(path.join(project, 'panelui.json'), '{}');
+  const result = run(['update', '--cwd', project]);
+  assert.equal(result.status, 1);
+  assert.match(`${result.stdout}${result.stderr}`, /cannot be proven unchanged/);
+});


### PR DESCRIPTION
## Summary
- record registry ownership and SHA-256 file digests in panelui.lock.json after successful add/overwrite writes
- add update [name...] with conflict-safe application and --check/--diff inspection
- update only files that still match their recorded install digest
- preserve modified or deleted files and report explicit conflicts
- create newly required registry dependency files safely and repair missing packages
- refuse legacy projects without trusted digests instead of guessing
- add end-to-end update, conflict, legacy, traversal, idempotence, and atomic-state tests

## Why
Copied component source could only be skipped or overwritten wholesale. Consumers had no way to receive upstream fixes without risking local customizations.

## Validation
- full CLI suite — 52/52 passed
- root typecheck and build — passed
- panelui-cli package dry-run — passed (13 entries; lock/update sources included)
- README/help parity — passed
- git diff check — passed

Legacy projects require an explicit add --overwrite to establish trusted provenance. Modified and deleted project-owned files are never silently replaced or recreated.