### PR TITLE
docs: add versioned migration hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -483,6 +483,8 @@ find them and had no way to change them — and the fixes to that are the bulk o
   server card, an A2A agent card, an agent-skills index with per-artifact digests, and `auth.md`
   saying plainly that everything here is public and takes no token.
 
+<a id="migration-0-60-0"></a>
+
 ### Migration
 
 - **A swipeable `Tabs` needs a height to lay its strip out in** — `className="flex-1"` on the tab
@@ -534,6 +536,8 @@ find them and had no way to change them — and the fixes to that are the bulk o
   was carrying the design: down the screen a stage is a row, so its count and its name compete with
   the shape for the same width, and both the shape and the names come off worse. Across the card a
   stage is a column and each reading has that column to itself.
+
+<a id="migration-0-59-0"></a>
 
 ### Migration
 
@@ -1384,6 +1388,8 @@ see the entry below this one for what it is.
 
 ### Changed
 
+<a id="migration-0-46-0"></a>
+
 - **Breaking: `KpiChart` is now `Kpi`**, and every `KpiChart*Props` type is `Kpi*Props`. It was
   never a chart — the number is the message, the sparkline is a footnote drawn by `LineChart`, and
   half its versions have no chart at all. Calling it one filed it with the plots and described the
@@ -1484,6 +1490,8 @@ see the entry below this one for what it is.
 ## [0.44.0] — 2026-08-05
 
 ### Changed
+
+<a id="migration-0-44-0"></a>
 
 - **Breaking:** `Card.Wash` and the `CardWashProps` type are removed. The wash was the only part
   of `Card` that did any work — a shared value, a repeating opacity animation, a resolved theme

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -3,6 +3,7 @@
     "---Sections---",
     "index",
     "installation",
+    "upgrading",
     "cli",
     "skills",
     "templates",

--- a/apps/docs/content/docs/upgrading.mdx
+++ b/apps/docs/content/docs/upgrading.mdx
@@ -12,7 +12,7 @@ an existing app.
 
 | Package              | Current  | Release                                                         | Source                                                                                                 |
 | -------------------- | -------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `panelui-native`     | `0.66.1` | [npm](https://www.npmjs.com/package/panelui-native/v/0.66.1)    | [package.json](https://github.com/panel-ui/PanelUI/blob/main/packages/panelui/package.json)            |
+| `panelui-native`     | `0.67.0` | [npm](https://www.npmjs.com/package/panelui-native/v/0.67.0)    | [package.json](https://github.com/panel-ui/PanelUI/blob/main/packages/panelui/package.json)            |
 | `panelui-cli`        | `0.4.2`  | [npm](https://www.npmjs.com/package/panelui-cli/v/0.4.2)        | [package.json](https://github.com/panel-ui/PanelUI/blob/main/packages/cli/package.json)                |
 | `create-panelui-app` | `0.2.0`  | [npm](https://www.npmjs.com/package/create-panelui-app/v/0.2.0) | [package.json](https://github.com/panel-ui/PanelUI/blob/main/packages/create-panelui-app/package.json) |
 

--- a/apps/docs/content/docs/upgrading.mdx
+++ b/apps/docs/content/docs/upgrading.mdx
@@ -1,0 +1,83 @@
+---
+title: Upgrading
+description: Upgrade PanelUI deliberately — current package versions, copied-source updates and the migrations that require code changes.
+---
+
+An upgrade has two parts: taking the new files, then changing any code whose contract moved. This
+page is the short index for the second part. The [changelog](https://github.com/panel-ui/PanelUI/blob/main/CHANGELOG.md)
+remains the complete release record; the entries here only point out releases that ask you to edit
+an existing app.
+
+## Current packages
+
+| Package              | Current  | Release                                                         | Source                                                                                                 |
+| -------------------- | -------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `panelui-native`     | `0.66.1` | [npm](https://www.npmjs.com/package/panelui-native/v/0.66.1)    | [package.json](https://github.com/panel-ui/PanelUI/blob/main/packages/panelui/package.json)            |
+| `panelui-cli`        | `0.4.2`  | [npm](https://www.npmjs.com/package/panelui-cli/v/0.4.2)        | [package.json](https://github.com/panel-ui/PanelUI/blob/main/packages/cli/package.json)                |
+| `create-panelui-app` | `0.2.0`  | [npm](https://www.npmjs.com/package/create-panelui-app/v/0.2.0) | [package.json](https://github.com/panel-ui/PanelUI/blob/main/packages/create-panelui-app/package.json) |
+
+These are checked against the package manifests. A release that changes one without updating this
+page fails the docs tests rather than leaving an old “current” version here.
+
+## Upgrade workflow
+
+1. Read every migration entry between the version you have and the version you want. The index
+   below is oldest first so the edits can be applied in release order.
+2. If you import the package, update it normally:
+
+   ```bash
+   npm install panelui-native@latest
+   npx expo install --check
+   ```
+
+3. If the CLI copied source into your app, those files are yours. Preview the registry version
+   first, then overwrite only after preserving local edits:
+
+   ```bash
+   npx panelui-cli@latest add button --dry-run
+   npx panelui-cli@latest add button --overwrite
+   ```
+
+4. Restart Metro after changing `extraThemes`, Metro configuration or the CSS entry, then run the
+   app and its typecheck. A reload does not make Metro reread its configuration.
+
+## Migration index
+
+### v0.44.0 — remove Card.Wash
+
+`Card.Wash` and `CardWashProps` were removed. Replace the wash with a decorative first child
+inside a clipping card, and install only the native dependency that decorative layer actually
+uses.
+
+[Release](https://github.com/panel-ui/PanelUI/releases/tag/v0.44.0) ·
+[Source notes](https://github.com/panel-ui/PanelUI/blob/main/CHANGELOG.md#migration-0-44-0)
+
+### v0.46.0 — rename KpiChart to Kpi
+
+Rename `KpiChart` and its `KpiChart*Props` types to `Kpi` and `Kpi*Props`. Copied-source projects
+must also replace the registry item: `add kpi-chart` no longer resolves, so install `kpi`.
+
+[Release](https://github.com/panel-ui/PanelUI/releases/tag/v0.46.0) ·
+[Source notes](https://github.com/panel-ui/PanelUI/blob/main/CHANGELOG.md#migration-0-46-0)
+
+### v0.59.0 — update FunnelChart geometry props
+
+Rename `stageHeight` to optional `stageSize` and `crossSize` to `height`. Remove `align`,
+`cornerRadius` and `orientation`; the chart is now a horizontal ribbon. `layers`, `edges` and
+`staggerDelay` control the replacement presentation.
+
+[Release](https://github.com/panel-ui/PanelUI/releases/tag/v0.59.0) ·
+[Source notes](https://github.com/panel-ui/PanelUI/blob/main/CHANGELOG.md#migration-0-59-0)
+
+### v0.60.0 — size swipeable Tabs and place Fab.Group at the screen root
+
+Give swipeable `Tabs` a layout height, such as `className="flex-1"`. Treat
+`keepMounted="measured"` as `true`. Place `Fab.Group` in the screen root because that parent owns
+its offset and scrim bounds.
+
+[Release](https://github.com/panel-ui/PanelUI/releases/tag/v0.60.0) ·
+[Source notes](https://github.com/panel-ui/PanelUI/blob/main/CHANGELOG.md#migration-0-60-0)
+
+For everything else — additions, fixes and changes that require no migration — continue in the
+[full changelog](https://github.com/panel-ui/PanelUI/blob/main/CHANGELOG.md) or browse
+[all releases](https://github.com/panel-ui/PanelUI/releases).

--- a/apps/docs/test/upgrading-docs.test.mjs
+++ b/apps/docs/test/upgrading-docs.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const docs = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const root = path.resolve(docs, "../..");
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const hub = read("apps/docs/content/docs/upgrading.mdx");
+const changelog = read("CHANGELOG.md");
+
+function migrationVersions() {
+  const headings = [...changelog.matchAll(/^## \[(\d+\.\d+\.\d+)\][^\n]*$/gm)];
+  const releases = headings.map((heading, index) => [
+    heading[1],
+    changelog.slice(
+      heading.index,
+      headings[index + 1]?.index ?? changelog.length,
+    ),
+  ]);
+  return releases
+    .filter(
+      ([, body]) =>
+        /^### Migration$/m.test(body) || /\*\*Breaking(?::|\b)/.test(body),
+    )
+    .map(([version]) => version);
+}
+
+test("the upgrade hub is present exactly once in primary docs navigation", () => {
+  const meta = JSON.parse(read("apps/docs/content/docs/meta.json"));
+  assert.equal(meta.pages.filter((page) => page === "upgrading").length, 1);
+  assert.equal(
+    fs.existsSync(path.join(docs, "content/docs/upgrading.mdx")),
+    true,
+  );
+});
+
+test("every changelog migration has one versioned hub entry with real links", () => {
+  const versions = migrationVersions();
+  assert.deepEqual(versions, ["0.60.0", "0.59.0", "0.46.0", "0.44.0"]);
+  const linkedAnchors = [
+    ...hub.matchAll(/CHANGELOG\.md#(migration-[\d-]+)/g),
+  ].map((match) => match[1]);
+  const linkedReleases = [
+    ...hub.matchAll(/releases\/tag\/v(\d+\.\d+\.\d+)/g),
+  ].map((match) => match[1]);
+  assert.deepEqual(
+    linkedAnchors,
+    [...versions]
+      .reverse()
+      .map((version) => `migration-${version.replaceAll(".", "-")}`),
+  );
+  assert.deepEqual(linkedReleases, [...versions].reverse());
+
+  for (const version of versions) {
+    const anchor = `migration-${version.replaceAll(".", "-")}`;
+    assert.equal(
+      (hub.match(new RegExp(`^### v${version}\\b`, "gm")) ?? []).length,
+      1,
+    );
+    assert.ok(
+      changelog.includes(`<a id="${anchor}"></a>`),
+      `${anchor} must exist`,
+    );
+    assert.ok(
+      hub.includes(
+        `https://github.com/panel-ui/PanelUI/blob/main/CHANGELOG.md#${anchor}`,
+      ),
+      `${version} source notes`,
+    );
+    assert.ok(
+      hub.includes(
+        `https://github.com/panel-ui/PanelUI/releases/tag/v${version}`,
+      ),
+      `${version} release`,
+    );
+  }
+});
+
+test("current package versions and source links match real manifests", () => {
+  const packages = [
+    ["packages/panelui/package.json", "panelui-native"],
+    ["packages/cli/package.json", "panelui-cli"],
+    ["packages/create-panelui-app/package.json", "create-panelui-app"],
+  ];
+
+  for (const [source, expectedName] of packages) {
+    const manifest = JSON.parse(read(source));
+    assert.equal(manifest.name, expectedName);
+    assert.match(
+      hub,
+      new RegExp(
+        "\\| `" + manifest.name + "`\\s+\\| `" + manifest.version + "`\\s+\\|",
+      ),
+    );
+    assert.ok(
+      hub.includes(
+        `https://www.npmjs.com/package/${manifest.name}/v/${manifest.version}`,
+      ),
+    );
+    assert.ok(
+      hub.includes(`https://github.com/panel-ui/PanelUI/blob/main/${source}`),
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add a primary-navigation upgrade hub with current package versions and source links
- index every CHANGELOG release explicitly marked Migration or Breaking
- add stable changelog anchors and validate version, source, release, and navigation parity
- keep full release prose in the changelog instead of duplicating it into drifting docs

## Validation
- docs tests: 11/11 passed
- docs typecheck passed
- docs generation repeated with identical output and stayed clean post-commit
- production docs build passed (301 static pages)
- git diff check passed
