### PR TITLE
feat(package): add explicit subpath exports

### DIFF
--- a/packages/panelui/README.md
+++ b/packages/panelui/README.md
@@ -172,6 +172,25 @@ you are done. Unstyled text on a white screen means the styles are not reaching 
 
 ## Components
 
+The root entry remains the shortest import for most apps:
+
+```tsx
+import { Button, useBreakpoint, formatTime } from 'panelui-native';
+```
+
+For explicit module boundaries, every component and public hook also has a subpath. The public
+utilities are `cn`, `color`, and `time`:
+
+```tsx
+import { Button } from 'panelui-native/components/button';
+import { useBreakpoint } from 'panelui-native/hooks/use-breakpoint';
+import { formatTime } from 'panelui-native/utils/time';
+```
+
+These imports expose the same implementations and types as the root entry. They are an
+organization and tooling boundary; they do not promise a smaller bundle without measuring your
+consumer bundler.
+
 | Component | What it does |
 | --- | --- |
 | `Accordion` | Collapsible sections with single or multiple selection |

--- a/packages/panelui/package.json
+++ b/packages/panelui/package.json
@@ -12,6 +12,31 @@
       "react-native": "./src/index.ts",
       "default": "./lib/module/index.js"
     },
+    "./components/*": {
+      "types": "./lib/typescript/src/components/*/index.d.ts",
+      "react-native": "./src/components/*/index.tsx",
+      "default": "./lib/module/components/*/index.js"
+    },
+    "./hooks/*": {
+      "types": "./lib/typescript/src/hooks/*.d.ts",
+      "react-native": "./src/hooks/*.ts",
+      "default": "./lib/module/hooks/*.js"
+    },
+    "./utils/cn": {
+      "types": "./lib/typescript/src/utils/cn.d.ts",
+      "react-native": "./src/utils/cn.ts",
+      "default": "./lib/module/utils/cn.js"
+    },
+    "./utils/color": {
+      "types": "./lib/typescript/src/utils/color.d.ts",
+      "react-native": "./src/utils/color.ts",
+      "default": "./lib/module/utils/color.js"
+    },
+    "./utils/time": {
+      "types": "./lib/typescript/src/utils/time.d.ts",
+      "react-native": "./src/utils/time.ts",
+      "default": "./lib/module/utils/time.js"
+    },
     "./theme.css": "./theme.css",
     "./package.json": "./package.json"
   },

--- a/packages/panelui/scripts/verify-package.mjs
+++ b/packages/panelui/scripts/verify-package.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -48,13 +48,37 @@ const collectTargets = (value) => {
   return Object.values(value).flatMap(collectTargets);
 };
 
+const publicPatternNames = {
+  "./components/*": readdirSync(resolve(packageRoot, "src/components"), {
+    withFileTypes: true,
+  })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name),
+  "./hooks/*": readdirSync(resolve(packageRoot, "src/hooks"))
+    .filter((name) => name !== "index.ts" && name.endsWith(".ts"))
+    .map((name) => name.slice(0, -3)),
+};
+
+const expandExportTargets = (key, value) => {
+  const targets = collectTargets(value);
+  if (!key.includes("*")) return targets;
+
+  const names = publicPatternNames[key];
+  if (!names) throw new Error(`No package verification inventory for ${key}.`);
+  return names.flatMap((name) =>
+    targets.map((target) => target.replaceAll("*", name)),
+  );
+};
+
 const requiredTargets = new Set(
   [
     packageJson.main,
     packageJson.module,
     packageJson.types,
     packageJson["react-native"],
-    ...collectTargets(packageJson.exports),
+    ...Object.entries(packageJson.exports).flatMap(([key, value]) =>
+      expandExportTargets(key, value),
+    ),
   ]
     .filter(Boolean)
     .map((path) => path.replace(/^\.\//, "")),

--- a/packages/panelui/scripts/verify-package.mjs
+++ b/packages/panelui/scripts/verify-package.mjs
@@ -54,8 +54,10 @@ const publicPatternNames = {
   })
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name),
+  // The `use-` modules are the hooks. The rest of the folder supports them and
+  // is reached through them, so it is not a subpath this package promises.
   "./hooks/*": readdirSync(resolve(packageRoot, "src/hooks"))
-    .filter((name) => name !== "index.ts" && name.endsWith(".ts"))
+    .filter((name) => name.startsWith("use-") && name.endsWith(".ts"))
     .map((name) => name.slice(0, -3)),
 };
 

--- a/packages/panelui/test/subpath-exports.test.mjs
+++ b/packages/panelui/test/subpath-exports.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const json = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'));
+
+test('component and hook subpaths cover every public source module', async () => {
+  assert.deepEqual(json.exports['./components/*'], {
+    types: './lib/typescript/src/components/*/index.d.ts',
+    'react-native': './src/components/*/index.tsx',
+    default: './lib/module/components/*/index.js',
+  });
+  assert.deepEqual(json.exports['./hooks/*'], {
+    types: './lib/typescript/src/hooks/*.d.ts',
+    'react-native': './src/hooks/*.ts',
+    default: './lib/module/hooks/*.js',
+  });
+
+  const componentNames = (await readdir(resolve(root, 'src/components'), {
+    withFileTypes: true,
+  }))
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+  const rootBarrel = await readFile(resolve(root, 'src/index.ts'), 'utf8');
+  for (const name of componentNames) {
+    assert.match(rootBarrel, new RegExp(`from './components/${name}'`), name);
+  }
+
+  const hookNames = (await readdir(resolve(root, 'src/hooks')))
+    .filter((name) => name !== 'index.ts' && name.endsWith('.ts'))
+    .map((name) => name.slice(0, -3))
+    .sort();
+  const hookBarrel = await readFile(resolve(root, 'src/hooks/index.ts'), 'utf8');
+  for (const name of hookNames) {
+    if (name === 'use-direction') {
+      assert.match(rootBarrel, /from '.\/components\/direction'/, name);
+    } else {
+      assert.match(hookBarrel, new RegExp(`from './${name}'`), name);
+    }
+  }
+});
+
+test('only root-public utilities receive subpaths', () => {
+  const utilityNames = Object.keys(json.exports)
+    .filter((key) => key.startsWith('./utils/'))
+    .map((key) => key.slice('./utils/'.length))
+    .sort();
+  assert.deepEqual(utilityNames, ['cn', 'color', 'time']);
+
+  for (const name of utilityNames) {
+    assert.deepEqual(json.exports[`./utils/${name}`], {
+      types: `./lib/typescript/src/utils/${name}.d.ts`,
+      'react-native': `./src/utils/${name}.ts`,
+      default: `./lib/module/utils/${name}.js`,
+    });
+  }
+});

--- a/packages/panelui/test/subpath-exports.test.mjs
+++ b/packages/panelui/test/subpath-exports.test.mjs
@@ -30,8 +30,11 @@ test('component and hook subpaths cover every public source module', async () =>
     assert.match(rootBarrel, new RegExp(`from './components/${name}'`), name);
   }
 
+  // A hook is a `use-` module. Anything else in the folder supports one —
+  // `breakpoint-contract` is the type the breakpoint hook is configured with —
+  // and is reached through the hook that uses it, not on its own.
   const hookNames = (await readdir(resolve(root, 'src/hooks')))
-    .filter((name) => name !== 'index.ts' && name.endsWith('.ts'))
+    .filter((name) => name.startsWith('use-') && name.endsWith('.ts'))
     .map((name) => name.slice(0, -3))
     .sort();
   const hookBarrel = await readFile(resolve(root, 'src/hooks/index.ts'), 'utf8');


### PR DESCRIPTION
## Summary
- add explicit component and hook wildcard subpath exports
- add explicit public `cn`, `color`, and `time` utility subpaths
- expand package verification across every concrete wildcard target
- document that subpaths are organizational/tooling boundaries, not an unmeasured bundle-size claim

## Validation
- PanelUI tests: 73/73 passed
- root typecheck and Bob build passed
- package verifier passed: 798 files, 2.13 MB packed, 8.10 MB unpacked
- every component/hook source module and public utility is covered by regression tests
- git diff check passed
