### PR TITLE
test: centralize contract suite discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,26 +31,8 @@ jobs:
       - name: Build library
         run: npm run build
 
-      - name: Node tests
-        run: |
-          # Discovered rather than globbed, so a workspace that grows its first
-          # test directory is covered without anybody remembering to add it here.
-          files=()
-          while IFS= read -r file; do files+=("$file"); done < <(
-            find packages apps -path '*/test/*.test.mjs' -not -path '*/node_modules/*' | sort
-          )
-          if [ ${#files[@]} -eq 0 ]; then
-            echo 'No test files found — the discovery pattern is wrong.'
-            exit 1
-          fi
-          printf '%s\n' "${files[@]}"
-          if grep -l -E '\.only[[:space:]]*\(' "${files[@]}"; then
-            echo 'Focused tests are not allowed in CI.'
-            exit 1
-          fi
-          # Some tests import the library's .ts sources directly. Type stripping
-          # is on by default from Node 22.18; the flag keeps earlier 22.x working.
-          node --experimental-strip-types --test "${files[@]}"
+      - name: Contract tests
+        run: npm test
 
       - name: Generated files are up to date
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,7 @@ which is worse than the gap it filled.
 
 - `npm install` — install all workspace deps
 - `npm run example` — start the example app (Metro/Expo dev server)
+- `npm test` — discover and run every repository contract test; rejects focused `.only` tests
 - `npm run typecheck` — typecheck all workspaces
 - `npm run build` — build the library with react-native-builder-bob (output: `lib/`)
 - `npm run docs` — start the docs site; `npm run build --workspace=docs` for a production build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ npm install
 | Command | What it does |
 | --- | --- |
 | `npm run example` | Start the Expo showcase app |
+| `npm test` | Discover and run every repository contract test |
 | `npm run typecheck` | Typecheck every workspace |
 | `npm run build` | Build the library with `react-native-builder-bob` |
 | `npm run docs` | Start the documentation site |
@@ -146,6 +147,7 @@ Keep a pull request to one logical change. Before you open it:
 
 ```sh
 npm run typecheck   # must pass
+npm test            # must pass; focused `.only` tests are rejected
 npm run build       # must pass
 ```
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ showcase in [`apps/example`](apps/example) and the documentation site in
 
 ```sh
 npm install         # install workspace deps
+npm test            # run every repository contract test
 npm run typecheck   # typecheck all workspaces
 npm run build       # build the library
 ```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "example": "npm run start --workspace=example",
+    "test": "node scripts/run-contract-tests.mjs",
     "build": "npm run build --workspace=panelui-native",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",

--- a/scripts/run-contract-tests.mjs
+++ b/scripts/run-contract-tests.mjs
@@ -1,0 +1,73 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = resolve(HERE, '..');
+const IGNORED_DIRECTORIES = new Set([
+  '.codegraph', '.git', '.next', '.expo', 'coverage', 'lib', 'node_modules',
+]);
+const TEST_FILE = /(?:^|\/)test\/[^/]+\.test\.mjs$/;
+const FOCUSED_TEST = /\b(?:test|it|describe)\.only\s*\(/;
+
+export async function discoverContractTests(root = REPO_ROOT) {
+  const found = [];
+
+  async function visit(directory) {
+    const entries = await readdir(directory, { withFileTypes: true });
+    await Promise.all(entries.map(async (entry) => {
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRECTORIES.has(entry.name)) {
+          await visit(resolve(directory, entry.name));
+        }
+        return;
+      }
+      const path = resolve(directory, entry.name);
+      const local = relative(root, path).replaceAll('\\', '/');
+      if (TEST_FILE.test(local)) found.push(local);
+    }));
+  }
+
+  await visit(root);
+  return found.sort();
+}
+
+export async function findFocusedTests(files, root = REPO_ROOT) {
+  const focused = [];
+  for (const file of files) {
+    if (FOCUSED_TEST.test(await readFile(resolve(root, file), 'utf8'))) {
+      focused.push(file);
+    }
+  }
+  return focused;
+}
+
+export async function runContractTests(root = REPO_ROOT) {
+  const files = await discoverContractTests(root);
+  if (files.length === 0) throw new Error('No contract tests found; discovery is broken.');
+
+  const focused = await findFocusedTests(files, root);
+  if (focused.length > 0) {
+    throw new Error(`Focused tests are not allowed:\n${focused.join('\n')}`);
+  }
+
+  console.log(`Running ${files.length} contract test files:`);
+  console.log(files.join('\n'));
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', '--test', ...files],
+    { cwd: root, stdio: 'inherit' },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`Contract tests exited with status ${result.status ?? 'unknown'}.`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runContractTests().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/test/contract-suite.test.mjs
+++ b/test/contract-suite.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  discoverContractTests,
+  findFocusedTests,
+} from '../scripts/run-contract-tests.mjs';
+
+async function fixture(files) {
+  const root = await mkdtemp(join(tmpdir(), 'panelui-contracts-'));
+  await Promise.all(Object.entries(files).map(async ([path, source]) => {
+    const target = join(root, path);
+    await mkdir(join(target, '..'), { recursive: true });
+    await writeFile(target, source);
+  }));
+  return root;
+}
+
+test('discovery covers root, package, app, and future workspace tests', async () => {
+  const root = await fixture({
+    'test/root.test.mjs': 'test("root", () => {})',
+    'packages/a/test/package.test.mjs': 'test("package", () => {})',
+    'apps/a/test/app.test.mjs': 'test("app", () => {})',
+    'future/a/test/future.test.mjs': 'test("future", () => {})',
+    'node_modules/no/test/ignored.test.mjs': 'test("ignored", () => {})',
+    'packages/a/test/not-a-spec.mjs': '',
+  });
+  assert.deepEqual(await discoverContractTests(root), [
+    'apps/a/test/app.test.mjs',
+    'future/a/test/future.test.mjs',
+    'packages/a/test/package.test.mjs',
+    'test/root.test.mjs',
+  ]);
+});
+
+test('focused test detection rejects test, it, and describe only', async () => {
+  const focusedCall = ['describe', '.only'].join('');
+  const root = await fixture({
+    'test/clean.test.mjs': 'test("clean", () => {})',
+    'test/focused.test.mjs': `${focusedCall}("focused", () => {})`,
+  });
+  const files = await discoverContractTests(root);
+  assert.deepEqual(await findFocusedTests(files, root), ['test/focused.test.mjs']);
+});


### PR DESCRIPTION
## Summary
- add one root `npm test` command that discovers every repository `test/*.test.mjs`
- include root, package, app, and future workspace tests while excluding generated/dependency directories
- reject focused `test.only`, `it.only`, and `describe.only` before execution
- replace CI-only shell discovery with the same tested local command and document it for contributors

## Validation
- discovery/focused-test regressions: 2/2 passed
- complete discovered suite: 134/134 passed across 39 files
- root workspace typecheck passed
- git diff check passed

This centralizes the existing behavior-first suites; it does not add broad snapshots or claim device coverage.
