### PR TITLE
ci(perf): gate shipped registry size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,10 @@ jobs:
       # bundled npm 10 therefore proved nothing about the environment the
       # release actually runs in, and let a verifier that crashed under npm 12
       # through to a tag that could not be published.
-      - name: Verify package contents, under the npm that will publish it
+      - name: Check shipped-surface budgets, under the npm that will publish
         run: |
           npm install -g npm@latest
           npm --version
-          npm run verify:package --workspace=panelui-native
+          # Reuses the release package verifier, then checks the generated
+          # registry served by the docs and downloaded by the CLI.
+          npm run performance:check

--- a/apps/docs/test/registry-budgets.test.mjs
+++ b/apps/docs/test/registry-budgets.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  assertRegistryBudgets,
+  measureRegistry,
+} from '../../../scripts/verify-registry-budgets.mjs';
+
+function fixture(t, sizes) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-registry-budget-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  sizes.forEach((size, index) =>
+    fs.writeFileSync(path.join(root, `${index}.json`), 'x'.repeat(size))
+  );
+  return measureRegistry(root);
+}
+
+test('measures generated registry responses deterministically', (t) => {
+  assert.deepEqual(fixture(t, [5, 12, 3]), {
+    files: 3,
+    totalBytes: 20,
+    largest: { file: '1.json', bytes: 12 },
+  });
+});
+
+test('accepts metrics at every declared ceiling', () => {
+  assert.doesNotThrow(() =>
+    assertRegistryBudgets(
+      { files: 2, totalBytes: 20, largest: { file: 'large.json', bytes: 12 } },
+      { files: 2, totalBytes: 20, itemBytes: 12 }
+    )
+  );
+});
+
+test('reports seeded file, aggregate, and individual-item regressions together', () => {
+  assert.throws(
+    () =>
+      assertRegistryBudgets(
+        { files: 3, totalBytes: 21, largest: { file: 'large.json', bytes: 13 } },
+        { files: 2, totalBytes: 20, itemBytes: 12 }
+      ),
+    /files: 3 > 2[\s\S]*total bytes: 21 > 20[\s\S]*large\.json is 13 bytes > 12/
+  );
+});

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "reset": "rm -rf apps/example/.expo apps/example/node_modules/.cache node_modules/.cache $TMPDIR/metro-* $TMPDIR/haste-map-* 2>/dev/null; echo \"caches cleared\"",
     "docs": "npm run dev --workspace=docs",
     "template": "node scripts/template-preview.mjs",
-    "template:parity": "node scripts/template-parity.mjs"
+    "template:parity": "node scripts/template-parity.mjs",
+    "performance:check": "npm run verify:package --workspace=panelui-native && node scripts/verify-registry-budgets.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/verify-registry-budgets.mjs
+++ b/scripts/verify-registry-budgets.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REGISTRY = path.resolve(HERE, '../apps/docs/public/r');
+
+/*
+ * These are capacity guards, not targets. At 137 items the generated registry
+ * is 2.88 MB and its largest response is 96 KB. The ceilings leave room for
+ * about 60 ordinary items, while still catching copied assets, bundled output,
+ * or accidentally duplicated source before it reaches the docs CDN and CLI.
+ */
+export const REGISTRY_BUDGETS = Object.freeze({
+  files: 200,
+  totalBytes: 4_500_000,
+  itemBytes: 150_000,
+});
+
+export function measureRegistry(directory) {
+  const items = fs
+    .readdirSync(directory)
+    .filter((file) => file.endsWith('.json'))
+    .sort()
+    .map((file) => ({ file, bytes: fs.statSync(path.join(directory, file)).size }));
+  if (items.length === 0) throw new Error('Registry contains no JSON items.');
+
+  return {
+    files: items.length,
+    totalBytes: items.reduce((total, item) => total + item.bytes, 0),
+    largest: items.reduce((largest, item) => (item.bytes > largest.bytes ? item : largest)),
+  };
+}
+
+export function assertRegistryBudgets(metrics, budgets = REGISTRY_BUDGETS) {
+  const exceeded = [];
+  if (metrics.files > budgets.files) {
+    exceeded.push(`files: ${metrics.files} > ${budgets.files}`);
+  }
+  if (metrics.totalBytes > budgets.totalBytes) {
+    exceeded.push(`total bytes: ${metrics.totalBytes} > ${budgets.totalBytes}`);
+  }
+  if (metrics.largest.bytes > budgets.itemBytes) {
+    exceeded.push(
+      `largest item: ${metrics.largest.file} is ${metrics.largest.bytes} bytes > ${budgets.itemBytes}`
+    );
+  }
+  if (exceeded.length > 0) {
+    throw new Error(`Registry exceeds its size budget:\n${exceeded.join('\n')}`);
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const metrics = measureRegistry(REGISTRY);
+  assertRegistryBudgets(metrics);
+  console.log(
+    `Verified registry: ${metrics.files} files, ${metrics.totalBytes} total bytes, ` +
+      `${metrics.largest.file} largest at ${metrics.largest.bytes} bytes.`
+  );
+}


### PR DESCRIPTION
## Summary
- add deterministic generated-registry file-count, aggregate-byte, and per-item budgets
- compose registry checks with the existing npm package verifier under one root performance command
- run the combined shipped-surface gate under release-equivalent npm in CI
- add seeded regressions for every budget failure mode

## Current measurements and ceilings
| Surface | Current | Ceiling |
|---|---:|---:|
| Package files | 798 | 1,200 |
| Package packed | 2,132,363 B | 4,000,000 B |
| Package unpacked | 8,098,871 B | 14,000,000 B |
| Registry JSON files | 137 | 200 |
| Registry total | 2,884,007 B | 4,500,000 B |
| Largest registry item | 96,045 B | 150,000 B |

## Validation
- focused regressions: 3/3 passed
- full repository tests: 135/135 passed
- root typecheck and library build passed
- combined performance gate passed
- production docs build passed (299 static pages)
- git diff check passed

This deliberately gates stable shipped bytes, not device frame time or other environment-sensitive measurements.
