### PR TITLE
test(a11y): enforce release accessibility gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Build library
         run: npm run build
 
+      - name: Accessibility contract gate
+        run: npm run test:a11y
+
       - name: Contract tests
         run: npm test
 

--- a/docs/accessibility-release-checklist.md
+++ b/docs/accessibility-release-checklist.md
@@ -1,0 +1,69 @@
+# Accessibility release checklist
+
+## Scope and limits
+
+Run `npm run test:a11y` first. It covers deterministic source contracts for
+contrast, reduced transparency, target sizes, modal isolation, structured
+content, accessible actions, and web composite keyboards. It is not an axe
+scan, WCAG certification, or substitute for assistive-technology testing.
+
+Test a release candidate on one current iOS device or simulator with VoiceOver
+and one current Android device or emulator with TalkBack. Record OS, device,
+app build, tester, and date. Use nontrivial data, large text, dark mode, and both
+portrait and landscape where the component supports them.
+
+## VoiceOver — iOS
+
+- **Dialog and nested overlays:** open a Dialog, then a nested menu or picker.
+  Focus enters the active overlay, background content is skipped, Escape/dismiss
+  closes only the top layer, and focus returns to the opener. Reference:
+  `packages/panelui/test/modal-isolation-store.test.mjs`.
+- **ContextMenu:** reach the trigger by swipe, invoke its Show Menu action,
+  traverse every item and dismiss it. The trigger remains named and disabled
+  state prevents opening. Reference:
+  `packages/panelui/test/context-menu-invocation.test.mjs`.
+- **Adjustable and reorder controls:** increment/decrement Slider and TimePicker,
+  then move a Sortable item with accessibility actions. Announced values stay
+  within bounds and each action changes exactly one step. References:
+  `packages/panelui/test/slider-haptics.test.mjs`,
+  `packages/panelui/test/time-picker-accessibility.test.mjs`, and
+  `packages/panelui/test/sortable-reorder.test.mjs`.
+- **Structured visuals:** traverse a populated Map, Flow, and chart. Meaningful
+  features/data are reachable without focusing decorative geometry, and an
+  actionable datum activates the same behavior as touch. Sources:
+  `packages/panelui/src/components/map/index.tsx`,
+  `packages/panelui/src/components/flow/index.tsx`, and
+  `packages/panelui/src/components/line-chart/index.tsx`.
+- **Signature:** hear empty/signed state, draw strokes, use undo/redo/clear, and
+  reach the product-provided alternative input method. Reference:
+  `packages/panelui/test/signature-accessibility.test.mjs`.
+
+## TalkBack — Android
+
+Repeat the VoiceOver scenarios using swipe navigation and the local context
+menu. Confirm roles, names, selected/disabled/expanded state, action results,
+overlay isolation, and focus return. Also verify 200% font size does not hide
+the active control or its label, and touch targets remain operable without
+overlap. Target-size reference: `packages/panelui/test/core-target-sizes.test.mjs`.
+
+## Keyboard — web
+
+- In InstallTabs, Tab reaches only the selected tab. Left/Right wrap, Home/End
+  select the edges, focus follows selection, and each panel is correctly linked.
+- In the theme radio group, one checked radio is tabbable; arrows wrap and
+  select, while Home/End select the edges.
+- Open ContextMenu with the Context Menu key and Shift+F10, dismiss with Escape,
+  and confirm focus remains on its trigger.
+
+Automated contract references: `apps/docs/test/composite-keyboard.test.mjs` and
+`packages/panelui/test/context-menu-invocation.test.mjs`.
+
+## Sign-off
+
+- [ ] `npm run test:a11y` passes at the release commit.
+- [ ] VoiceOver scenarios pass; device/build evidence is linked.
+- [ ] TalkBack scenarios pass; device/build evidence is linked.
+- [ ] Keyboard scenarios pass in a supported browser.
+- [ ] Failures are filed with component, platform, build, steps, expected
+      announcement/focus, and actual announcement/focus. No claim of full WCAG
+      or device coverage is made from this checklist alone.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "apps/*"
   ],
   "scripts": {
+    "test:a11y": "node scripts/accessibility-gate.mjs",
     "example": "npm run start --workspace=example",
     "test": "node scripts/run-contract-tests.mjs",
     "build": "npm run build --workspace=panelui-native",

--- a/packages/panelui/test/accessibility-gate.test.mjs
+++ b/packages/panelui/test/accessibility-gate.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  ACCESSIBILITY_SUITES,
+  CHECKLIST,
+  validateAccessibilityGate,
+} from '../../../scripts/accessibility-gate.mjs';
+
+const root = path.resolve(import.meta.dirname, '../../..');
+
+test('the accessibility gate covers every required class and contract suite', () => {
+  assert.deepEqual(validateAccessibilityGate({ root }), []);
+});
+
+test('the accessibility gate rejects a removed class, suite, or required test', () => {
+  const withoutClass = ACCESSIBILITY_SUITES.filter((suite) => suite.class !== 'target-size');
+  assert.ok(validateAccessibilityGate({ root, suites: withoutClass })
+    .some((error) => error.includes('Missing required accessibility class: target-size')));
+
+  const missingSuite = ACCESSIBILITY_SUITES.map((suite, index) =>
+    index === 0 ? { ...suite, file: 'packages/panelui/test/renamed.test.mjs' } : suite
+  );
+  assert.ok(validateAccessibilityGate({ root, suites: missingSuite })
+    .some((error) => error.includes('Missing accessibility suite')));
+
+  const missingTest = ACCESSIBILITY_SUITES.map((suite, index) =>
+    index === 0 ? { ...suite, anchor: 'renamed required contract' } : suite
+  );
+  assert.ok(validateAccessibilityGate({ root, suites: missingTest })
+    .some((error) => error.includes('is missing required test')));
+});
+
+test('the accessibility gate rejects an incomplete manual checklist', (t) => {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-a11y-gate-'));
+  t.after(() => fs.rmSync(temporaryRoot, { recursive: true, force: true }));
+  const checklistPath = path.join(temporaryRoot, CHECKLIST);
+  fs.mkdirSync(path.dirname(checklistPath), { recursive: true });
+  const manual = fs.readFileSync(path.join(root, CHECKLIST), 'utf8');
+  fs.writeFileSync(checklistPath, manual.replace('## TalkBack — Android', '## Android'));
+  const errors = validateAccessibilityGate({ root: temporaryRoot, suites: [], checklist: CHECKLIST });
+  assert.ok(errors.some((error) => error.includes('Manual checklist is missing section')));
+});

--- a/scripts/accessibility-gate.mjs
+++ b/scripts/accessibility-gate.mjs
@@ -1,0 +1,169 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+export const ACCESSIBILITY_SUITES = [
+  {
+    class: 'gate-integrity',
+    file: 'packages/panelui/test/accessibility-gate.test.mjs',
+    count: 3,
+    anchor: 'the accessibility gate rejects a removed class, suite, or required test',
+  },
+  {
+    class: 'perception',
+    file: 'packages/panelui/test/theme-solid-contrast.test.mjs',
+    count: 3,
+    anchor: 'solid text pairs clear the WCAG AA normal-text floor',
+  },
+  {
+    class: 'perception',
+    file: 'packages/panelui/test/scrim-transparency.test.mjs',
+    count: 6,
+    anchor: 'rendering decisions suppress blur until it is explicitly allowed',
+  },
+  {
+    class: 'target-size',
+    file: 'packages/panelui/test/core-target-sizes.test.mjs',
+    count: 1,
+    anchor: 'compact core controls keep 48dp interaction boxes',
+  },
+  {
+    class: 'modal-isolation',
+    file: 'packages/panelui/test/modal-isolation-store.test.mjs',
+    count: 3,
+    anchor: 'closing one nested modal keeps the app isolated for the other',
+  },
+  {
+    class: 'structured-content',
+    file: 'packages/panelui/test/flow-accessibility.test.mjs',
+    count: 4,
+    anchor: 'the node owns actions and visual handles no longer claim button behavior',
+  },
+  {
+    class: 'structured-content',
+    file: 'packages/panelui/test/map-accessibility.test.mjs',
+    count: 3,
+    anchor: 'describes every feature from the same FeatureCollection used by the layer',
+  },
+  {
+    class: 'accessible-actions',
+    file: 'packages/panelui/test/context-menu-invocation.test.mjs',
+    count: 3,
+    anchor: 'ContextMenu accessibility actions preserve menu and primary activation semantics',
+  },
+  {
+    class: 'accessible-actions',
+    file: 'packages/panelui/test/signature-accessibility.test.mjs',
+    count: 4,
+    anchor: 'only currently usable signature actions are exposed',
+  },
+  {
+    class: 'accessible-actions',
+    file: 'packages/panelui/test/slider-haptics.test.mjs',
+    count: 4,
+    anchor: 'accessibility changes update the same per-thumb history',
+  },
+  {
+    class: 'accessible-actions',
+    file: 'packages/panelui/test/sortable-reorder.test.mjs',
+    count: 5,
+    anchor: 'accessibility steps cross adjacent pinned slots without moving them',
+  },
+  {
+    class: 'accessible-actions',
+    file: 'packages/panelui/test/time-picker-accessibility.test.mjs',
+    count: 5,
+    anchor: 'disabled adjustable controls ignore actions',
+  },
+  {
+    class: 'web-keyboard',
+    file: 'apps/docs/test/composite-keyboard.test.mjs',
+    count: 4,
+    anchor: 'horizontal tabs wrap and support Home and End without consuming vertical keys',
+  },
+];
+
+export const REQUIRED_CLASSES = [
+  'gate-integrity',
+  'perception',
+  'target-size',
+  'modal-isolation',
+  'structured-content',
+  'accessible-actions',
+  'web-keyboard',
+];
+
+export const CHECKLIST = 'docs/accessibility-release-checklist.md';
+export const CHECKLIST_SECTIONS = [
+  '## Scope and limits',
+  '## VoiceOver — iOS',
+  '## TalkBack — Android',
+  '## Keyboard — web',
+  '## Sign-off',
+];
+
+function testNames(source) {
+  return [...source.matchAll(/\b(?:test|it)\(\s*(['"`])([^'"`\n]+)\1/g)].map((match) => match[2]);
+}
+
+export function validateAccessibilityGate({
+  root = ROOT,
+  suites = ACCESSIBILITY_SUITES,
+  checklist = CHECKLIST,
+} = {}) {
+  const errors = [];
+  const classes = new Set(suites.map((suite) => suite.class));
+  for (const required of REQUIRED_CLASSES) {
+    if (!classes.has(required)) errors.push(`Missing required accessibility class: ${required}`);
+  }
+
+  for (const suite of suites) {
+    const absolute = path.join(root, suite.file);
+    if (!fs.existsSync(absolute)) {
+      errors.push(`Missing accessibility suite: ${suite.file}`);
+      continue;
+    }
+    const names = testNames(fs.readFileSync(absolute, 'utf8'));
+    if (names.length !== suite.count) {
+      errors.push(`${suite.file} must contain ${suite.count} tests; found ${names.length}`);
+    }
+    if (!names.includes(suite.anchor)) {
+      errors.push(`${suite.file} is missing required test: ${suite.anchor}`);
+    }
+  }
+
+  const checklistPath = path.join(root, checklist);
+  if (!fs.existsSync(checklistPath)) return [...errors, `Missing manual checklist: ${checklist}`];
+  const manual = fs.readFileSync(checklistPath, 'utf8');
+  for (const section of CHECKLIST_SECTIONS) {
+    if (!manual.includes(section)) errors.push(`Manual checklist is missing section: ${section}`);
+  }
+  for (const match of manual.matchAll(/`((?:packages|apps)\/[^`]+)`/g)) {
+    if (!fs.existsSync(path.join(root, match[1]))) {
+      errors.push(`Manual checklist references a missing path: ${match[1]}`);
+    }
+  }
+  return errors;
+}
+
+function run() {
+  const errors = validateAccessibilityGate();
+  if (errors.length) {
+    console.error(errors.map((error) => `- ${error}`).join('\n'));
+    process.exitCode = 1;
+    return;
+  }
+  const files = [...new Set(ACCESSIBILITY_SUITES.map((suite) => suite.file))];
+  console.log(`Accessibility gate: ${REQUIRED_CLASSES.length} classes, ${files.length} suites`);
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-strip-types', '--test', ...files],
+    { cwd: ROOT, stdio: 'inherit' }
+  );
+  process.exitCode = result.status ?? 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) run();


### PR DESCRIPTION
## Summary
- add a root accessibility gate covering 13 explicit suites and 48 behavior tests across seven required classes
- fail on missing/renamed suites, reduced test counts, missing anchor tests, or incomplete checklist sections
- run the gate as a dedicated CI step
- add a bounded VoiceOver, TalkBack, and keyboard-web release checklist with evidence/sign-off fields

## Automated scope
Perception, 48dp targets, modal isolation, structured Flow/Map content, accessible actions, and docs composite keyboard contracts.

## Validation
- accessibility gate: 48/48 passed
- complete CI-style suite: 39 files / 135 tests passed
- root typecheck and Bob build passed
- docs production build passed (299 static pages)
- git diff check passed

This is not axe coverage, WCAG certification, or a substitute for native assistive-technology testing. The checklist explicitly owns that residual boundary.
