### PR TITLE
ci: verify shipped package surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
             exit 1
           fi
 
+      - name: Build documentation
+        run: npm run build --workspace=docs
+
+      - name: Verify packed CLI consumers
+        run: npm run verify:cli-packages
+
       - name: Template typechecks
         run: |
           # The templates ship to users with their own dependency sets, so they
@@ -93,3 +99,22 @@ jobs:
           # Reuses the release package verifier, then checks the generated
           # registry served by the docs and downloaded by the CLI.
           npm run performance:check
+
+  node20-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test supported CLI runtime
+        run: npm run test:cli
+
+      - name: Verify packed CLI consumers
+        run: npm run verify:cli-packages

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   ],
   "scripts": {
     "test:a11y": "node scripts/accessibility-gate.mjs",
+    "test:cli": "node --test packages/cli/test/*.test.mjs",
+    "verify:cli-packages": "node scripts/verify-cli-packages.mjs",
     "example": "npm run start --workspace=example",
     "test": "node scripts/run-contract-tests.mjs",
     "build": "npm run build --workspace=panelui-native",

--- a/packages/cli/test/shipped-surface-ci.test.mjs
+++ b/packages/cli/test/shipped-surface-ci.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('../../..', import.meta.url));
+const workflow = fs.readFileSync(new URL('../../../.github/workflows/ci.yml', import.meta.url), 'utf8');
+const pkg = JSON.parse(fs.readFileSync(new URL('../../../package.json', import.meta.url), 'utf8'));
+
+test('CI owns docs production build and packed CLI smoke commands', () => {
+  assert.match(workflow, /name: Build documentation[\s\S]*npm run build --workspace=docs/);
+  assert.match(workflow, /name: Verify packed CLI consumers[\s\S]*npm run verify:cli-packages/);
+  assert.equal(pkg.scripts['verify:cli-packages'], 'node scripts/verify-cli-packages.mjs');
+  assert.ok(fs.existsSync(`${root}/scripts/verify-cli-packages.mjs`));
+});
+
+test('Node 20 compatibility job owns the supported CLI boundary', () => {
+  assert.match(workflow, /node20-compatibility:[\s\S]*node-version: 20/);
+  assert.match(workflow, /node20-compatibility:[\s\S]*npm run test:cli/);
+  assert.match(workflow, /node20-compatibility:[\s\S]*npm run verify:cli-packages/);
+  assert.equal(pkg.scripts['test:cli'], 'node --test packages/cli/test/*.test.mjs');
+});

--- a/scripts/verify-cli-packages.mjs
+++ b/scripts/verify-cli-packages.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+function packageVersion(packageRoot) {
+  return JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8')).version;
+}
+
+function pack(directory, destination) {
+  const output = execFileSync(
+    npm,
+    ['pack', '--json', '--ignore-scripts', '--pack-destination', destination],
+    { cwd: directory, encoding: 'utf8' }
+  );
+  const parsed = JSON.parse(output);
+  const [manifest] = Array.isArray(parsed) ? parsed : Object.values(parsed);
+  if (!manifest?.filename) throw new Error(`npm pack returned no archive for ${directory}`);
+  return { manifest, archive: path.join(destination, manifest.filename) };
+}
+
+function verifyManifest(packageRoot, manifest) {
+  const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
+  const files = new Set(manifest.files.map(({ path: file }) => file));
+  assert.ok(files.has('package.json'), `${pkg.name} omitted package.json`);
+  assert.ok(files.has('README.md'), `${pkg.name} omitted README.md`);
+  for (const target of Object.values(pkg.bin ?? {})) {
+    assert.ok(files.has(target), `${pkg.name} omitted bin target ${target}`);
+  }
+  for (const target of Object.values(pkg.exports ?? {})) {
+    if (typeof target === 'string') {
+      assert.ok(files.has(target.replace(/^\.\//, '')), `${pkg.name} omitted export ${target}`);
+    }
+  }
+  const forbidden = [...files].filter((file) =>
+    file.includes('/test/') || file.includes('.test.') || file.endsWith('.tsbuildinfo')
+  );
+  assert.deepEqual(forbidden, [], `${pkg.name} packed development files`);
+}
+
+function runBinary(bin, args, expected) {
+  const output = execFileSync(process.execPath, [bin, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+  assert.match(output, expected);
+}
+
+const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-packed-cli-'));
+try {
+  const cliRoot = path.join(ROOT, 'packages/cli');
+  const createRoot = path.join(ROOT, 'packages/create-panelui-app');
+  const cli = pack(cliRoot, temporary);
+  const create = pack(createRoot, temporary);
+  verifyManifest(cliRoot, cli.manifest);
+  verifyManifest(createRoot, create.manifest);
+
+  const consumer = path.join(temporary, 'consumer');
+  fs.mkdirSync(consumer);
+  fs.writeFileSync(path.join(consumer, 'package.json'), '{"private":true}');
+  execFileSync(npm, ['install', '--ignore-scripts', '--no-audit', '--no-fund', cli.archive], {
+    cwd: consumer,
+    stdio: 'inherit',
+  });
+  execFileSync(
+    npm,
+    ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--force', create.archive],
+    { cwd: consumer, stdio: 'inherit' }
+  );
+
+  runBinary(path.join(consumer, 'node_modules/panelui-cli/bin/panelui.mjs'), ['--help'], /Commands/);
+  runBinary(
+    path.join(consumer, 'node_modules/panelui-cli/bin/panelui.mjs'),
+    ['--version'],
+    new RegExp(packageVersion(cliRoot).replaceAll('.', '\\.'))
+  );
+  runBinary(path.join(consumer, 'node_modules/create-panelui-app/index.mjs'), ['--help'], /new Expo app/);
+  runBinary(
+    path.join(consumer, 'node_modules/create-panelui-app/index.mjs'),
+    ['--version'],
+    new RegExp(packageVersion(createRoot).replaceAll('.', '\\.'))
+  );
+  console.log(
+    `Verified packed CLI surfaces: ${cli.manifest.entryCount} panelui-cli files, ` +
+      `${create.manifest.entryCount} create-panelui-app files.`
+  );
+} finally {
+  fs.rmSync(temporary, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- add a production docs build to the primary CI job
- pack both CLI packages, inspect their archives, install them into a fresh consumer, and execute their shipped binaries
- add a focused Node 20 compatibility job for the declared minimum runtime
- add workflow ownership tests so these shipped-surface checks cannot silently disappear

## Validation
- packed consumer verification passed: 11 CLI files, 3 create-app files, fresh install, four binary invocations
- CLI tests: 52/52 passed
- full discovered suite: 39 files / 134 tests passed
- root typecheck and Bob build passed
- docs production build passed (299 static pages)
- docs generation stayed clean
- library verifier passed (798 files / 2,132,363 packed bytes)
- git diff check passed

Node 20 was unavailable locally; the new setup-node 20 CI job is the compatibility authority. Native Expo runtime smoke remains outside this bounded gate.
