### PR TITLE
test(a11y): gate chart semantics

### DIFF
--- a/docs/accessibility-release-checklist.md
+++ b/docs/accessibility-release-checklist.md
@@ -4,8 +4,9 @@
 
 Run `npm run test:a11y` first. It covers deterministic source contracts for
 contrast, reduced transparency, target sizes, modal isolation, structured
-content, accessible actions, and web composite keyboards. It is not an axe
-scan, WCAG certification, or substitute for assistive-technology testing.
+content, chart semantics, accessible actions, and web composite keyboards. It
+is not an axe scan, WCAG certification, or substitute for assistive-technology
+testing.
 
 Test a release candidate on one current iOS device or simulator with VoiceOver
 and one current Android device or emulator with TalkBack. Record OS, device,
@@ -31,6 +32,7 @@ portrait and landscape where the component supports them.
 - **Structured visuals:** traverse a populated Map, Flow, and chart. Meaningful
   features/data are reachable without focusing decorative geometry, and an
   actionable datum activates the same behavior as touch. Sources:
+  `packages/panelui/test/chart-accessibility.test.mjs`,
   `packages/panelui/src/components/map/index.tsx`,
   `packages/panelui/src/components/flow/index.tsx`, and
   `packages/panelui/src/components/line-chart/index.tsx`.

--- a/packages/panelui/test/accessibility-gate.test.mjs
+++ b/packages/panelui/test/accessibility-gate.test.mjs
@@ -15,22 +15,32 @@ test('the accessibility gate covers every required class and contract suite', ()
   assert.deepEqual(validateAccessibilityGate({ root }), []);
 });
 
-test('the accessibility gate rejects a removed class, suite, or required test', () => {
-  const withoutClass = ACCESSIBILITY_SUITES.filter((suite) => suite.class !== 'target-size');
+test('the accessibility gate rejects a removed class, suite, required test, or count drift', () => {
+  const withoutClass = ACCESSIBILITY_SUITES.filter((suite) => suite.class !== 'chart-semantics');
   assert.ok(validateAccessibilityGate({ root, suites: withoutClass })
-    .some((error) => error.includes('Missing required accessibility class: target-size')));
+    .some((error) => error.includes('Missing required accessibility class: chart-semantics')));
 
-  const missingSuite = ACCESSIBILITY_SUITES.map((suite, index) =>
-    index === 0 ? { ...suite, file: 'packages/panelui/test/renamed.test.mjs' } : suite
+  const missingSuite = ACCESSIBILITY_SUITES.map((suite) =>
+    suite.class === 'chart-semantics'
+      ? { ...suite, file: 'packages/panelui/test/renamed.test.mjs' }
+      : suite
   );
   assert.ok(validateAccessibilityGate({ root, suites: missingSuite })
     .some((error) => error.includes('Missing accessibility suite')));
 
-  const missingTest = ACCESSIBILITY_SUITES.map((suite, index) =>
-    index === 0 ? { ...suite, anchor: 'renamed required contract' } : suite
+  const missingTest = ACCESSIBILITY_SUITES.map((suite) =>
+    suite.class === 'chart-semantics'
+      ? { ...suite, anchor: 'renamed required contract' }
+      : suite
   );
   assert.ok(validateAccessibilityGate({ root, suites: missingTest })
     .some((error) => error.includes('is missing required test')));
+
+  const staleCount = ACCESSIBILITY_SUITES.map((suite) =>
+    suite.class === 'chart-semantics' ? { ...suite, count: suite.count + 1 } : suite
+  );
+  assert.ok(validateAccessibilityGate({ root, suites: staleCount })
+    .some((error) => error.includes('must contain 5 tests; found 4')));
 });
 
 test('the accessibility gate rejects an incomplete manual checklist', (t) => {

--- a/scripts/accessibility-gate.mjs
+++ b/scripts/accessibility-gate.mjs
@@ -10,7 +10,7 @@ export const ACCESSIBILITY_SUITES = [
     class: 'gate-integrity',
     file: 'packages/panelui/test/accessibility-gate.test.mjs',
     count: 3,
-    anchor: 'the accessibility gate rejects a removed class, suite, or required test',
+    anchor: 'the accessibility gate rejects a removed class, suite, required test, or count drift',
   },
   {
     class: 'perception',
@@ -47,6 +47,12 @@ export const ACCESSIBILITY_SUITES = [
     file: 'packages/panelui/test/map-accessibility.test.mjs',
     count: 3,
     anchor: 'describes every feature from the same FeatureCollection used by the layer',
+  },
+  {
+    class: 'chart-semantics',
+    file: 'packages/panelui/test/chart-accessibility.test.mjs',
+    count: 4,
+    anchor: 'all confirmed chart families use the shared semantic sibling',
   },
   {
     class: 'accessible-actions',
@@ -92,6 +98,7 @@ export const REQUIRED_CLASSES = [
   'target-size',
   'modal-isolation',
   'structured-content',
+  'chart-semantics',
   'accessible-actions',
   'web-keyboard',
 ];


### PR DESCRIPTION
## What this changes

Adds the existing chart semantics contract suite to the centralized accessibility release gate, including integrity checks for class, suite, anchor, and test-count drift.

## Why

Chart accessibility coverage shipped separately and was not executed by `npm run test:a11y`, so the release gate could stay green if chart semantics regressed.

## Type of change

- [ ] Bug fix
- [ ] New component
- [ ] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [ ] Documentation only
- [x] Internal: refactor, tooling, CI

## How it was tested

- [ ] iOS
- [ ] Android
- [ ] Light and dark themes
- [x] `npm run test:a11y` — 52/52
- [x] `npm test` — 209/209
- [x] `npm run build`
- [x] `npm run typecheck`

## Screenshots or recording

Not applicable; this changes release validation only.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No component runtime or public API changed

## Notes for the reviewer

The chart suite already existed; this PR only makes it an explicit, removal-resistant part of the accessibility gate and updates the manual checklist source reference.
