### PR TITLE
feat(cli): show unified update diffs

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -51,6 +51,8 @@ replace an existing file and makes that new copy eligible for later safe updates
 Fetches tracked components again and updates only files whose digest still matches the copy the CLI
 installed. Locally edited or deleted files are reported as conflicts and never replaced. Omit names
 to update every tracked component. Files removed upstream are deleted only when still untouched.
+Before prompting or exiting in preview mode, the command prints three-line-context unified diffs for
+every safe changed, added, or removed file. Conflicts are listed but their contents are never printed.
 
 ```bash
 npx panelui-cli@latest update

--- a/packages/cli/bin/panelui.mjs
+++ b/packages/cli/bin/panelui.mjs
@@ -23,7 +23,7 @@ ${bold('Commands')}
   init                 In an empty folder, start a new app from a template.
                        In an existing one, set it up to receive components.
   add <name...>        Copy components in, with everything they depend on
-  update [name...]     Safely update unchanged installed component files
+  update [name...]     Diff and safely update unchanged component files
   list                 Discover registry items; filter with --type or --search
   doctor               Check project setup without changing it
   mcp                  Run the MCP server, so an agent can read the registry

--- a/packages/cli/src/diff.mjs
+++ b/packages/cli/src/diff.mjs
@@ -1,0 +1,174 @@
+const CONTEXT_LINES = 3;
+const MAX_MYERS_LINES = 500;
+
+function lines(source) {
+  return source.match(/[^\n]*\n|[^\n]+$/g) ?? [];
+}
+
+function editScript(before, after) {
+  let prefix = 0;
+  while (
+    prefix < before.length &&
+    prefix < after.length &&
+    before[prefix] === after[prefix]
+  ) {
+    prefix += 1;
+  }
+
+  let suffix = 0;
+  while (
+    suffix < before.length - prefix &&
+    suffix < after.length - prefix &&
+    before[before.length - suffix - 1] === after[after.length - suffix - 1]
+  ) {
+    suffix += 1;
+  }
+
+  const leading = before.slice(0, prefix).map((line) => ({ type: ' ', line }));
+  const trailing = before
+    .slice(before.length - suffix)
+    .map((line) => ({ type: ' ', line }));
+  const oldMiddle = before.slice(prefix, before.length - suffix);
+  const newMiddle = after.slice(prefix, after.length - suffix);
+
+  // New/deleted files are linear. Very large rewrites also use a valid,
+  // non-minimal replacement instead of letting Myers' trace grow quadratically.
+  if (
+    !oldMiddle.length ||
+    !newMiddle.length ||
+    oldMiddle.length + newMiddle.length > MAX_MYERS_LINES
+  ) {
+    return [
+      ...leading,
+      ...oldMiddle.map((line) => ({ type: '-', line })),
+      ...newMiddle.map((line) => ({ type: '+', line })),
+      ...trailing,
+    ];
+  }
+
+  const trace = [];
+  let frontier = new Map([[1, 0]]);
+  const limit = oldMiddle.length + newMiddle.length;
+
+  for (let depth = 0; depth <= limit; depth += 1) {
+    trace.push(frontier);
+    const next = new Map();
+    for (let diagonal = -depth; diagonal <= depth; diagonal += 2) {
+      const down = frontier.get(diagonal + 1) ?? -1;
+      const right = frontier.get(diagonal - 1) ?? -1;
+      let x =
+        diagonal === -depth || (diagonal !== depth && right < down)
+          ? down
+          : right + 1;
+      let y = x - diagonal;
+      while (
+        x < oldMiddle.length &&
+        y < newMiddle.length &&
+        oldMiddle[x] === newMiddle[y]
+      ) {
+        x += 1;
+        y += 1;
+      }
+      next.set(diagonal, x);
+      if (x >= oldMiddle.length && y >= newMiddle.length) {
+        return [
+          ...leading,
+          ...backtrack(trace, oldMiddle, newMiddle),
+          ...trailing,
+        ];
+      }
+    }
+    frontier = next;
+  }
+
+  throw new Error('Could not compute diff');
+}
+
+function backtrack(trace, before, after) {
+  const edits = [];
+  let x = before.length;
+  let y = after.length;
+
+  for (let depth = trace.length - 1; depth >= 0; depth -= 1) {
+    const frontier = trace[depth];
+    const diagonal = x - y;
+    const down = frontier.get(diagonal + 1) ?? -1;
+    const right = frontier.get(diagonal - 1) ?? -1;
+    const previousDiagonal =
+      diagonal === -depth || (diagonal !== depth && right < down)
+        ? diagonal + 1
+        : diagonal - 1;
+    const previousX = frontier.get(previousDiagonal) ?? 0;
+    const previousY = previousX - previousDiagonal;
+
+    while (x > previousX && y > previousY) {
+      edits.push({ type: ' ', line: before[x - 1] });
+      x -= 1;
+      y -= 1;
+    }
+    if (depth === 0) break;
+    if (x === previousX) {
+      edits.push({ type: '+', line: after[y - 1] });
+      y -= 1;
+    } else {
+      edits.push({ type: '-', line: before[x - 1] });
+      x -= 1;
+    }
+  }
+
+  return edits.reverse();
+}
+
+function range(start, count) {
+  if (count === 0) return `${start - 1},0`;
+  return count === 1 ? String(start) : `${start},${count}`;
+}
+
+function renderLine({ type, line }) {
+  const terminated = line.endsWith('\n');
+  const rendered = `${type}${terminated ? line.slice(0, -1) : line}`;
+  return terminated ? [rendered] : [rendered, '\\ No newline at end of file'];
+}
+
+/** Return a deterministic, three-line-context unified text diff. */
+export function unifiedDiff(file, current, incoming) {
+  if (current === incoming) return '';
+
+  const before = lines(current ?? '');
+  const after = lines(incoming ?? '');
+  const edits = editScript(before, after);
+  const oldPositions = [1];
+  const newPositions = [1];
+  for (const edit of edits) {
+    oldPositions.push(oldPositions.at(-1) + (edit.type === '+' ? 0 : 1));
+    newPositions.push(newPositions.at(-1) + (edit.type === '-' ? 0 : 1));
+  }
+
+  const changed = edits.flatMap((edit, index) =>
+    edit.type === ' ' ? [] : [index],
+  );
+  const hunks = [];
+  for (const index of changed) {
+    const start = Math.max(0, index - CONTEXT_LINES);
+    const end = Math.min(edits.length, index + CONTEXT_LINES + 1);
+    const previous = hunks.at(-1);
+    if (previous && start <= previous.end)
+      previous.end = Math.max(previous.end, end);
+    else hunks.push({ start, end });
+  }
+
+  const output = [
+    `--- ${current === null ? '/dev/null' : `a/${file}`}`,
+    `+++ ${incoming === null ? '/dev/null' : `b/${file}`}`,
+  ];
+  for (const hunk of hunks) {
+    const slice = edits.slice(hunk.start, hunk.end);
+    const oldCount = slice.filter((edit) => edit.type !== '+').length;
+    const newCount = slice.filter((edit) => edit.type !== '-').length;
+    output.push(
+      `@@ -${range(oldPositions[hunk.start], oldCount)} +${range(newPositions[hunk.start], newCount)} @@`,
+    );
+    for (const edit of slice) output.push(...renderLine(edit));
+  }
+  return output.join('\n');
+}

--- a/packages/cli/src/update.mjs
+++ b/packages/cli/src/update.mjs
@@ -4,6 +4,7 @@ import { applyAliases, detectProject, projectPath, requireConfig, targetPath } f
 import { digest, LOCK_FILE, readLock, writeLock } from './lock.mjs';
 import { collectDependencies, resolve } from './registry.mjs';
 import { installDependencies } from './patch.mjs';
+import { unifiedDiff } from './diff.mjs';
 import { bold, confirm, dim, fail, info, success, warn } from './ui.mjs';
 
 export async function update(names, options) {
@@ -35,11 +36,12 @@ export async function update(names, options) {
       const content = applyAliases(file.content, config);
       const tracked = lock.files[relative];
       const current = fs.existsSync(destination) ? fs.readFileSync(destination, 'utf8') : null;
-      let status = 'update';
+      let status;
       if (current === content) status = 'current';
-      else if (current === null) status = tracked ? 'conflict' : 'update';
+      else if (current === null) status = tracked ? 'conflict' : 'add';
       else if (!tracked || digest(current) !== tracked.digest) status = 'conflict';
-      candidates.push({ item: item.name, destination, relative, content, status });
+      else status = 'update';
+      candidates.push({ item: item.name, destination, relative, current, content, status });
     }
   }
 
@@ -52,6 +54,7 @@ export async function update(names, options) {
       item: tracked.item,
       destination,
       relative,
+      current,
       status: current !== null && digest(current) === tracked.digest ? 'remove' : 'conflict',
     });
   }
@@ -60,18 +63,27 @@ export async function update(names, options) {
   info(`Checking ${requested.map(bold).join(', ')}`);
   info('');
   for (const file of candidates) {
-    const marker = { current: '·', update: '~', remove: '-', conflict: '!' }[file.status];
+    const marker = { current: '·', add: '+', update: '~', remove: '-', conflict: '!' }[file.status];
     const note = file.status === 'conflict' ? ' (modified)' : file.status === 'remove' ? ' (removed upstream)' : '';
     info(`  ${marker} ${file.relative}${dim(note)}`);
   }
 
-  const safe = candidates.filter((file) => file.status === 'update' || file.status === 'remove');
+  const safe = candidates.filter(
+    (file) => file.status === 'add' || file.status === 'update' || file.status === 'remove'
+  );
   const conflicts = candidates.filter((file) => file.status === 'conflict');
   const preview = options.check || options.dryRun;
   const project = detectProject(cwd);
   const { dependencies } = collectDependencies(items);
   const missing = dependencies.filter((dependency) => !(dependency in project.deps));
   if (missing.length) info(dim(`  + install ${missing.join(', ')}`));
+  if (safe.length) {
+    info('');
+    safe.forEach((file, index) => {
+      info(unifiedDiff(file.relative, file.current, file.status === 'remove' ? null : file.content));
+      if (index < safe.length - 1) info('');
+    });
+  }
   if (conflicts.length) {
     warn(`${conflicts.length} modified or untracked file${conflicts.length === 1 ? '' : 's'} left alone.`);
   }

--- a/packages/cli/test/safe-update.test.mjs
+++ b/packages/cli/test/safe-update.test.mjs
@@ -96,16 +96,23 @@ test('update writes only digest-matching files and reports modified files', asyn
     const lockBeforeCheck = fs.readFileSync(path.join(project, 'panelui-lock.json'), 'utf8');
     const checked = run(['update', '--check', ...common], installEnv);
     assert.equal(checked.status, 1, `${checked.stdout}${checked.stderr}`);
+    assert.match(checked.stdout, /--- a\/components\/ui\/card\.tsx\n\+\+\+ b\/components\/ui\/card\.tsx/);
+    assert.match(checked.stdout, /--- \/dev\/null\n\+\+\+ b\/lib\/helper\.ts/);
+    assert.match(checked.stdout, /--- a\/components\/ui\/removed\.ts\n\+\+\+ \/dev\/null/);
+    assert.doesNotMatch(checked.stdout, /--- a\/components\/ui\/card-style\.ts/);
     assert.equal(fs.existsSync(marker), false);
     assert.equal(fs.readFileSync(path.join(project, 'components/ui/card.tsx'), 'utf8'), beforeCheck);
     assert.equal(fs.readFileSync(path.join(project, 'panelui-lock.json'), 'utf8'), lockBeforeCheck);
-    assert.equal(run(['update', '--dry-run', ...common], installEnv).status, 1);
+    const dryRun = run(['update', '--dry-run', ...common], installEnv);
+    assert.equal(dryRun.status, 1);
+    assert.match(dryRun.stdout, /@@ -1 \+1 @@\n-card v1\n\+card v2/);
     assert.equal(fs.existsSync(marker), false);
     assert.equal(fs.readFileSync(path.join(project, 'panelui-lock.json'), 'utf8'), lockBeforeCheck);
 
     const updated = run(['update', ...common], installEnv);
     const output = `${updated.stdout}${updated.stderr}`;
     assert.equal(updated.status, 1, output);
+    assert.match(output, /@@ -1 \+1 @@\n-card v1\n\+card v2/);
     assert.equal(fs.readFileSync(path.join(project, 'components/ui/card.tsx'), 'utf8'), 'card v2\n');
     assert.equal(
       fs.readFileSync(path.join(project, 'components/ui/card-style.ts'), 'utf8'),

--- a/packages/cli/test/update-diff.test.mjs
+++ b/packages/cli/test/update-diff.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { unifiedDiff } from '../src/diff.mjs';
+
+test('unifiedDiff renders updates with three lines of context', () => {
+  assert.equal(
+    unifiedDiff(
+      'components/ui/card.tsx',
+      'one\ntwo\nthree\n',
+      'one\nchanged\nthree\n',
+    ),
+    [
+      '--- a/components/ui/card.tsx',
+      '+++ b/components/ui/card.tsx',
+      '@@ -1,3 +1,3 @@',
+      ' one',
+      '-two',
+      '+changed',
+      ' three',
+    ].join('\n'),
+  );
+});
+
+test('unifiedDiff uses dev/null and preserves missing-final-newline markers', () => {
+  assert.equal(
+    unifiedDiff('lib/helper.ts', null, 'first\nlast'),
+    [
+      '--- /dev/null',
+      '+++ b/lib/helper.ts',
+      '@@ -0,0 +1,2 @@',
+      '+first',
+      '+last',
+      '\\ No newline at end of file',
+    ].join('\n'),
+  );
+  assert.equal(
+    unifiedDiff('lib/helper.ts', 'first\nlast', null),
+    [
+      '--- a/lib/helper.ts',
+      '+++ /dev/null',
+      '@@ -1,2 +0,0 @@',
+      '-first',
+      '-last',
+      '\\ No newline at end of file',
+    ].join('\n'),
+  );
+});
+
+test('unifiedDiff separates distant changes into deterministic hunks', () => {
+  const before = 'a\nb\nc\nd\ne\nf\ng\nh\ni\n';
+  const output = unifiedDiff(
+    'value.txt',
+    before,
+    before.replace('a\n', 'A\n').replace('i\n', 'I\n'),
+  );
+  assert.equal(output.match(/^@@ /gm)?.length, 2);
+  assert.match(output, /@@ -1,4 \+1,4 @@/);
+  assert.match(output, /@@ -6,4 \+6,4 @@/);
+});
+
+test('unifiedDiff handles large replacements without an unbounded edit trace', () => {
+  const before = `${Array.from({ length: 251 }, (_, index) => `old ${index}`).join('\n')}\n`;
+  const after = `${Array.from({ length: 251 }, (_, index) => `new ${index}`).join('\n')}\n`;
+  const output = unifiedDiff('large.txt', before, after);
+  assert.match(output, /@@ -1,251 \+1,251 @@/);
+  assert.match(output, /-old 250\n\+new 0/);
+});


### PR DESCRIPTION
## What this changes

Adds deterministic three-line-context unified diffs to safe component updates, including additions, removals, multiple hunks, and missing-final-newline markers.

## Why

The update command only printed status markers even though its documentation promised a diff. Users had to approve registry changes without seeing the exact safe edits the CLI intended to apply.

## Type of change

- [ ] Bug fix
- [ ] New component
- [x] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [ ] Documentation only
- [ ] Internal: refactor, tooling, CI

## How it was tested

- [ ] iOS
- [ ] Android
- [ ] Light and dark themes
- [x] Focused diff/update tests — 7/7
- [x] Full CLI suite — 68/68
- [x] Root library build — 167 files
- [x] CLI package dry-run includes the diff module

## Screenshots or recording

Not applicable; representative unified-diff output is asserted end to end.

## Checklist

- [x] PanelUI typecheck passes
- [x] `npm run build` passes
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] CLI README/help updated
- [x] Conflicted file contents are never printed or modified

## Notes for the reviewer

The implementation has no new dependency. New/deleted files are linear; large rewrites use a bounded valid replacement diff instead of an unbounded edit trace. Check/dry-run remain read-only.
