### PR TITLE
perf(example): gate production export size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Build library
         run: npm run build
 
+      # A real production Metro export catches dependency and asset growth that
+      # source-level package budgets cannot see. Offline mode and a cold cache
+      # keep this reproducible; the current export takes about 15 seconds.
+      - name: Check example production export budget
+        run: npm run performance:example
+
       - name: Accessibility contract gate
         run: npm run test:a11y
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ npm install
 | `npm test` | Discover and run every repository contract test |
 | `npm run typecheck` | Typecheck every workspace |
 | `npm run build` | Build the library with `react-native-builder-bob` |
+| `npm run performance:example` | Production-export the Android showcase and check its bundle budget |
 | `npm run docs` | Start the documentation site |
 | `npm run docs:generate --workspace=docs` | Regenerate the docs pages and the CLI registry |
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "docs": "npm run dev --workspace=docs",
     "template": "node scripts/template-preview.mjs",
     "template:parity": "node scripts/template-parity.mjs",
+    "performance:example": "node scripts/verify-example-export.mjs",
     "performance:check": "npm run verify:package --workspace=panelui-native && node scripts/verify-registry-budgets.mjs"
   },
   "engines": {

--- a/scripts/verify-example-export.mjs
+++ b/scripts/verify-example-export.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const EXAMPLE = path.join(ROOT, 'apps/example');
+
+/*
+ * Baseline (Expo 57, 108 component catalogue): 4,161 modules, a 6,640,222
+ * byte minified bundle, 33 assets / 1,019,361 bytes, eight route entries and
+ * 7,661,810 output bytes. These are capacity guards with 6–50% headroom,
+ * depending on how discrete the metric is, rather than targets to fill.
+ */
+export const EXAMPLE_EXPORT_BUDGETS = Object.freeze({
+  modules: 4_400,
+  bundleBytes: 7_100_000,
+  assets: 40,
+  assetBytes: 1_150_000,
+  routes: 12,
+  files: 45,
+  totalBytes: 8_300_000,
+});
+
+function filesBelow(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const target = path.join(directory, entry.name);
+    return entry.isDirectory() ? filesBelow(target) : [target];
+  });
+}
+
+function containedFile(root, relative) {
+  const target = path.resolve(root, relative);
+  if (!target.startsWith(`${path.resolve(root)}${path.sep}`)) {
+    throw new Error(`Export metadata escaped its output directory: ${relative}`);
+  }
+  return target;
+}
+
+export function measureExampleExport(outputDirectory, log, appDirectory = EXAMPLE) {
+  const metadata = JSON.parse(
+    fs.readFileSync(path.join(outputDirectory, 'metadata.json'), 'utf8'),
+  );
+  const platforms = Object.keys(metadata.fileMetadata ?? {});
+  if (platforms.join(',') !== 'android') {
+    throw new Error(`Expected one Android export, received: ${platforms.join(', ')}`);
+  }
+
+  const android = metadata.fileMetadata.android;
+  const bundle = containedFile(outputDirectory, android.bundle);
+  const assets = android.assets.map((asset) => containedFile(outputDirectory, asset.path));
+  if (new Set(assets).size !== assets.length) {
+    throw new Error('Expo export metadata contains duplicate assets.');
+  }
+  const moduleMatch = log.match(/Android Bundled[^\n]*\(([\d,]+) modules\)/);
+  if (!moduleMatch) throw new Error('Expo output did not report its module count.');
+
+  const outputFiles = filesBelow(outputDirectory);
+  const routeFiles = filesBelow(path.join(appDirectory, 'app'))
+    .filter((file) => /\.[jt]sx?$/.test(file))
+    .filter((file) => !path.basename(file).startsWith('_'));
+
+  return {
+    modules: Number(moduleMatch[1].replaceAll(',', '')),
+    bundle: path.relative(outputDirectory, bundle).replaceAll(path.sep, '/'),
+    bundleBytes: fs.statSync(bundle).size,
+    assets: assets.length,
+    assetBytes: assets.reduce((sum, file) => sum + fs.statSync(file).size, 0),
+    routes: routeFiles.length,
+    files: outputFiles.length,
+    totalBytes: outputFiles.reduce((sum, file) => sum + fs.statSync(file).size, 0),
+  };
+}
+
+export function assertExampleExportBudgets(
+  metrics,
+  budgets = EXAMPLE_EXPORT_BUDGETS,
+) {
+  const exceeded = [];
+  for (const key of [
+    'modules',
+    'bundleBytes',
+    'assets',
+    'assetBytes',
+    'routes',
+    'files',
+    'totalBytes',
+  ]) {
+    if (metrics[key] > budgets[key]) {
+      exceeded.push(`${key}: ${metrics[key]} > ${budgets[key]}`);
+    }
+  }
+  if (exceeded.length) {
+    throw new Error(`Example export exceeds its budget:\n${exceeded.join('\n')}`);
+  }
+}
+
+export function formatExampleExport(metrics) {
+  return (
+    `Verified Android example export: ${metrics.modules} modules, ` +
+    `${metrics.bundleBytes} bundle bytes (${metrics.bundle}), ` +
+    `${metrics.assets} assets / ${metrics.assetBytes} asset bytes, ` +
+    `${metrics.routes} routes, ${metrics.files} files / ${metrics.totalBytes} total bytes.`
+  );
+}
+
+export function verifyExampleExport() {
+  const output = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-expo-export-'));
+  const { FORCE_COLOR: _forceColor, NO_COLOR: _noColor, ...baseEnv } = process.env;
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(ROOT, 'node_modules/expo/bin/cli'),
+        'export',
+        '--platform',
+        'android',
+        '--output-dir',
+        output,
+        '--clear',
+        // Hermes bytecode embeds a nondeterministic byte in otherwise identical
+        // exports. Budget the stable, minified production JavaScript instead.
+        '--no-bytecode',
+        '--max-workers',
+        '2',
+      ],
+      {
+        cwd: EXAMPLE,
+        encoding: 'utf8',
+        env: { ...baseEnv, CI: '1', EXPO_OFFLINE: '1', NO_COLOR: '1' },
+        maxBuffer: 20_000_000,
+      },
+    );
+    const log = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(`Expo export failed with status ${result.status}:\n${log}`);
+    }
+    const metrics = measureExampleExport(output, log);
+    assertExampleExportBudgets(metrics);
+    console.log(formatExampleExport(metrics));
+    return metrics;
+  } finally {
+    fs.rmSync(output, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    verifyExampleExport();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/test/example-export-budget.test.mjs
+++ b/test/example-export-budget.test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import {
+  EXAMPLE_EXPORT_BUDGETS,
+  assertExampleExportBudgets,
+  measureExampleExport,
+} from '../scripts/verify-example-export.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-export-budget-'));
+  const output = path.join(root, 'output');
+  const app = path.join(root, 'example');
+  const write = (file, bytes) => {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, Buffer.alloc(bytes));
+  };
+  write(path.join(output, 'bundle.hbc'), 10);
+  write(path.join(output, 'assets/a'), 4);
+  write(path.join(output, 'assets/b'), 6);
+  write(path.join(output, 'metadata.json'), 1);
+  write(path.join(app, 'app/_layout.tsx'), 0);
+  write(path.join(app, 'app/index.tsx'), 0);
+  write(path.join(app, 'app/item/[id].tsx'), 0);
+  fs.writeFileSync(
+    path.join(output, 'metadata.json'),
+    JSON.stringify({
+      fileMetadata: {
+        android: {
+          bundle: 'bundle.hbc',
+          assets: [{ path: 'assets/a' }, { path: 'assets/b' }],
+        },
+      },
+    }),
+  );
+  return { root, output, app };
+}
+
+test('measures the exported artifact and route surface deterministically', (t) => {
+  const { root, output, app } = fixture();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const first = measureExampleExport(output, 'Android Bundled (4,161 modules)', app);
+  const second = measureExampleExport(output, 'Android Bundled (4,161 modules)', app);
+  assert.deepEqual(first, second);
+  assert.deepEqual(first, {
+    modules: 4161,
+    bundle: 'bundle.hbc',
+    bundleBytes: 10,
+    assets: 2,
+    assetBytes: 10,
+    routes: 2,
+    files: 4,
+    totalBytes: 123,
+  });
+});
+
+test('reports every exceeded capacity in one actionable failure', () => {
+  const metrics = Object.fromEntries(
+    Object.entries(EXAMPLE_EXPORT_BUDGETS).map(([key, value]) => [key, value + 1]),
+  );
+  assert.throws(
+    () => assertExampleExportBudgets(metrics),
+    (error) =>
+      Object.keys(EXAMPLE_EXPORT_BUDGETS).every((key) =>
+        error.message.includes(`${key}:`),
+      ),
+  );
+});
+
+test('CI runs the production export gate by its public command', () => {
+  const workflow = fs.readFileSync(path.join(ROOT, '.github/workflows/ci.yml'), 'utf8');
+  const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  assert.equal(
+    packageJson.scripts['performance:example'],
+    'node scripts/verify-example-export.mjs',
+  );
+  assert.equal(workflow.match(/run: npm run performance:example/g)?.length, 1);
+});


### PR DESCRIPTION
## What this changes

Adds a deterministic offline Android production-export gate for the example app, budgeting module, bundle, asset, route, file, and total output growth in CI.

## Why

Existing package and registry budgets do not observe the actual Metro/Expo application graph. A dependency or asset regression could substantially grow the shipped showcase without crossing either source-level gate.

## Type of change

- [ ] Bug fix
- [ ] New component
- [ ] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [ ] Documentation only
- [x] Internal: refactor, tooling, CI

## How it was tested

- [ ] iOS
- [x] Android production export
- [ ] Light and dark themes
- [x] Two cold offline exports produced identical metrics
- [x] Focused budget tests — 3/3
- [x] Full contract suite — 211/211
- [x] Root typecheck/build and existing performance gates

## Screenshots or recording

Not applicable; this is a production artifact budget.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes (167 files)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] CI cost is bounded (about 15 seconds after the library build)
- [x] Temporary export output is always removed

## Notes for the reviewer

Baseline: 4,161 modules; 6,640,222 bundle bytes; 33 assets / 1,019,361 bytes; 8 source route entries; 36 files / 7,661,810 total bytes. Hermes bytecode differed by one byte between identical cold exports, so this intentionally budgets stable minified production JavaScript with `--no-bytecode`.
