### PR TITLE
feat(cli): track requested dependency roots

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -169,8 +169,14 @@ A value-taking flag without its value prints its usage and exits with status 1. 
 
 Change the aliases and imports are rewritten to match on the way in.
 
-`panelui-lock.json` records SHA-256 digests and registry ownership for files successfully copied by
-`add` or `update`. Commit it with the project so updates have the same safety baseline everywhere.
+`panelui-lock.json` records SHA-256 digests, requested roots, and each root's registry dependency
+closure. That lets a named update remove an untouched dependency only after no other requested root
+needs it. Locally edited files and dependencies shared with another root are always retained. Commit
+the lockfile so updates have the same safety baseline everywhere.
+
+Version 1 lockfiles remain readable, but their missing root history makes dependency pruning unsafe.
+Run `add <root>` again while its dependencies are still present to migrate that root to version 2;
+use `--overwrite` only when you also intend to reset edited files.
 
 ## Notes
 

--- a/packages/cli/src/add.mjs
+++ b/packages/cli/src/add.mjs
@@ -5,7 +5,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { applyAliases, detectProject, requireConfig, targetPath } from './config.mjs';
 import { discover, kindOf } from './discovery.mjs';
-import { collectDependencies, fetchIndex, resolve } from './registry.mjs';
+import { collectDependencies, dependencyClosures, fetchIndex, resolve } from './registry.mjs';
 import { installDependencies } from './patch.mjs';
 import { recordInstalled } from './lock.mjs';
 import { bold, confirm, dim, fail, info, step, success, warn } from './ui.mjs';
@@ -22,6 +22,7 @@ export async function add(names, options) {
   const registry = options.registry ?? config.registry;
 
   const items = await resolve(registry, names);
+  const closures = dependencyClosures(items, names);
 
   // Dependencies the user did not ask for are shown separately: taking three
   // extra files because you asked for one is fine, but it should not be a
@@ -82,9 +83,10 @@ export async function add(names, options) {
       fs.mkdirSync(path.dirname(write.destination), { recursive: true });
       fs.writeFileSync(write.destination, write.content);
     }
-    recordInstalled(cwd, pending, registry);
+    recordInstalled(cwd, pending, registry, closures);
     success(`Wrote ${pending.length} file${pending.length === 1 ? '' : 's'}`);
   } else {
+    if (!options.dryRun) recordInstalled(cwd, [], registry, closures);
     success('Component files are already installed.');
   }
 

--- a/packages/cli/src/lock.mjs
+++ b/packages/cli/src/lock.mjs
@@ -14,22 +14,48 @@ export function readLock(cwd) {
   if (!fs.existsSync(file)) return null;
   try {
     const value = JSON.parse(fs.readFileSync(file, 'utf8'));
-    if (!value || value.version !== 1 || !value.files || Array.isArray(value.files)) return null;
-    return Object.values(value.files).every(
+    if (!value || ![1, 2].includes(value.version) || !value.files || Array.isArray(value.files)) {
+      return null;
+    }
+    const filesValid = Object.values(value.files).every(
       (entry) => typeof entry?.item === 'string' && /^sha256:[a-f0-9]{64}$/.test(entry.digest)
-    ) ? value : null;
+    );
+    if (!filesValid) return null;
+    if (value.version === 1) return value;
+    const rootsValid =
+      value.roots &&
+      !Array.isArray(value.roots) &&
+      Object.values(value.roots).every(
+        (closure) => Array.isArray(closure) && closure.every((item) => typeof item === 'string')
+      );
+    const legacyValid =
+      Array.isArray(value.legacyFiles) && value.legacyFiles.every((file) => typeof file === 'string');
+    return rootsValid && legacyValid ? value : null;
   } catch {
     return null;
   }
 }
 
-export function recordInstalled(cwd, writes, registry) {
-  const lock = readLock(cwd) ?? { version: 1, files: {} };
+export function recordInstalled(cwd, writes, registry, closures) {
+  const current = readLock(cwd);
+  const lock = current?.version === 2
+    ? current
+    : {
+        version: 2,
+        files: current?.files ?? {},
+        roots: {},
+        legacyFiles: Object.keys(current?.files ?? {}),
+      };
   lock.registry = registry;
+  lock.roots = { ...lock.roots, ...closures };
   for (const write of writes) {
     const relative = write.relative.split(path.sep).join('/');
     lock.files[relative] = { item: write.item, digest: digest(write.content) };
   }
+  const claimed = new Set(Object.values(closures).flat());
+  lock.legacyFiles = lock.legacyFiles.filter(
+    (relative) => !claimed.has(lock.files[relative]?.item)
+  );
   writeLock(cwd, lock);
 }
 

--- a/packages/cli/src/registry.mjs
+++ b/packages/cli/src/registry.mjs
@@ -180,6 +180,25 @@ export async function resolve(registry, names) {
   return [...resolved.values()];
 }
 
+/** The resolved item names owned by each root the user explicitly requested. */
+export function dependencyClosures(items, roots) {
+  const byName = new Map(items.map((item) => [item.name, item]));
+  return Object.fromEntries(
+    roots.map((root) => {
+      const closure = [];
+      const visited = new Set();
+      const visit = (name) => {
+        if (visited.has(name)) return;
+        visited.add(name);
+        closure.push(name);
+        for (const dependency of byName.get(name)?.registryDependencies ?? []) visit(dependency);
+      };
+      visit(root);
+      return [root, closure];
+    })
+  );
+}
+
 /** The union of npm packages a set of items needs. */
 export function collectDependencies(items) {
   const required = new Set();

--- a/packages/cli/src/update.mjs
+++ b/packages/cli/src/update.mjs
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { applyAliases, detectProject, projectPath, requireConfig, targetPath } from './config.mjs';
 import { digest, LOCK_FILE, readLock, writeLock } from './lock.mjs';
-import { collectDependencies, resolve } from './registry.mjs';
+import { collectDependencies, dependencyClosures, resolve } from './registry.mjs';
 import { installDependencies } from './patch.mjs';
 import { bold, confirm, dim, fail, info, success, warn } from './ui.mjs';
 
@@ -18,15 +18,29 @@ export async function update(names, options) {
   }
 
   const installed = [...new Set(Object.values(lock.files).map((entry) => entry.item))];
-  const requested = names.length ? names : installed;
-  const unknown = requested.filter((name) => !installed.includes(name));
+  const roots = lock.version === 2 ? Object.keys(lock.roots) : installed;
+  const requested = names.length ? names : roots;
+  const unknown = requested.filter((name) => !roots.includes(name));
   if (unknown.length) {
-    fail(`Not tracked as installed: ${unknown.join(', ')}.`, 'Use `add` for new components.');
+    fail(`Not tracked as a requested root: ${unknown.join(', ')}.`, 'Use `add` for new components.');
   }
-  if (!requested.length) fail(`No tracked components in ${LOCK_FILE}.`);
+  if (!requested.length) fail(`No tracked roots in ${LOCK_FILE}.`);
+
+  if (lock.version === 1) {
+    warn(
+      `${LOCK_FILE} v1 cannot prune former dependencies safely. Re-run \`add <root>\` before dependencies change to record requested roots.`
+    );
+  }
 
   const registry = options.registry ?? config.registry;
   const items = await resolve(registry, requested);
+  const resolvedItems = new Set(items.map((item) => item.name));
+  const closures = dependencyClosures(items, requested);
+  const nextRoots = lock.version === 2 ? { ...lock.roots, ...closures } : null;
+  const protectedItems = new Set(Object.values(nextRoots ?? {}).flat());
+  const legacyFiles = new Set(lock.version === 2 ? lock.legacyFiles : Object.keys(lock.files));
+  const ownershipChanged =
+    lock.version === 2 && JSON.stringify(lock.roots) !== JSON.stringify(nextRoots);
   const candidates = [];
   for (const item of items) {
     for (const file of item.files) {
@@ -45,7 +59,11 @@ export async function update(names, options) {
 
   const incoming = new Set(candidates.map((file) => file.relative));
   for (const [relative, tracked] of Object.entries(lock.files)) {
-    if (!requested.includes(tracked.item) || incoming.has(relative)) continue;
+    if (incoming.has(relative)) continue;
+    const removedUpstream = resolvedItems.has(tracked.item);
+    const orphaned =
+      lock.version === 2 && !legacyFiles.has(relative) && !protectedItems.has(tracked.item);
+    if (!removedUpstream && !orphaned) continue;
     const destination = projectPath(cwd, relative, 'Tracked file path');
     const current = fs.existsSync(destination) ? fs.readFileSync(destination, 'utf8') : null;
     candidates.push({
@@ -76,7 +94,7 @@ export async function update(names, options) {
     warn(`${conflicts.length} modified or untracked file${conflicts.length === 1 ? '' : 's'} left alone.`);
   }
 
-  if (!preview && (safe.length || missing.length)) {
+  if (!preview && (safe.length || missing.length || ownershipChanged)) {
     if (safe.length && !(await confirm(`Apply ${safe.length} file change${safe.length === 1 ? '' : 's'}?`, options))) {
       info(dim('Cancelled.'));
       return;
@@ -89,25 +107,34 @@ export async function update(names, options) {
         fs.writeFileSync(file.destination, file.content);
       }
     }
-    if (safe.length) {
+    if (safe.length || ownershipChanged) {
       const nextLock = structuredClone(lock);
       nextLock.registry = registry;
       for (const file of candidates.filter((entry) => entry.status !== 'conflict')) {
         if (file.status === 'remove') delete nextLock.files[file.relative];
         else nextLock.files[file.relative] = { item: file.item, digest: digest(file.content) };
       }
+      if (nextLock.version === 2) {
+        nextLock.roots = nextRoots;
+        nextLock.legacyFiles = nextLock.legacyFiles.filter(
+          (relative) => Object.hasOwn(nextLock.files, relative)
+        );
+      }
       writeLock(cwd, nextLock);
-      success(`Applied ${safe.length} file change${safe.length === 1 ? '' : 's'}`);
+      if (safe.length) success(`Applied ${safe.length} file change${safe.length === 1 ? '' : 's'}`);
+      else success('Updated dependency ownership metadata.');
     }
   } else if (!preview) {
     if (!conflicts.length) success('Tracked component files are current.');
-  } else if (safe.length || missing.length) {
-    const count = safe.length + missing.length;
+  } else if (safe.length || missing.length || ownershipChanged) {
+    const count = safe.length + missing.length + (ownershipChanged ? 1 : 0);
     info(dim(`${count} safe update${count === 1 ? '' : 's'} available; nothing written.`));
   } else if (!conflicts.length) {
     success('Tracked component files are current.');
   }
 
-  if ((preview && (safe.length || missing.length)) || conflicts.length) process.exitCode = 1;
+  if ((preview && (safe.length || missing.length || ownershipChanged)) || conflicts.length) {
+    process.exitCode = 1;
+  }
   info('');
 }

--- a/packages/cli/src/update.mjs
+++ b/packages/cli/src/update.mjs
@@ -18,7 +18,17 @@ export async function update(names, options) {
   }
 
   const installed = [...new Set(Object.values(lock.files).map((entry) => entry.item))];
-  const roots = lock.version === 2 ? Object.keys(lock.roots) : installed;
+  // Components installed before the lock recorded roots are still the user's to
+  // update. Their files sit in `legacyFiles` because no closure claims them,
+  // which says nothing about whether they were asked for — so each such item is
+  // a root too. Without this, the first `add` after an upgrade migrates the
+  // lock to v2 and silently narrows `update` to whatever was added since.
+  const adopted =
+    lock.version === 2
+      ? lock.legacyFiles.map((relative) => lock.files[relative]?.item).filter(Boolean)
+      : [];
+  const roots =
+    lock.version === 2 ? [...new Set([...Object.keys(lock.roots), ...adopted])] : installed;
   const requested = names.length ? names : roots;
   const unknown = requested.filter((name) => !roots.includes(name));
   if (unknown.length) {

--- a/packages/cli/test/root-closures.test.mjs
+++ b/packages/cli/test/root-closures.test.mjs
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { after, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { digest, writeLock } from '../src/lock.mjs';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'panelui-root-closures-'));
+const cli = fileURLToPath(new URL('../bin/panelui.mjs', import.meta.url));
+after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+function item(registry, name, file, dependencies = []) {
+  fs.writeFileSync(
+    path.join(registry, `${name}.json`),
+    JSON.stringify({ name, files: [{ path: file, content: `${name}\n` }], registryDependencies: dependencies })
+  );
+}
+
+function project(name) {
+  const directory = path.join(root, name);
+  fs.mkdirSync(directory);
+  fs.writeFileSync(path.join(directory, 'package.json'), '{"dependencies":{}}');
+  fs.writeFileSync(
+    path.join(directory, 'panelui.json'),
+    JSON.stringify({
+      registry: 'https://panelui.dev/r',
+      aliases: { components: '@/components/ui', lib: '@/lib', hooks: '@/hooks' },
+    })
+  );
+  return directory;
+}
+
+async function registryServer(registry) {
+  const server = spawn(
+    process.execPath,
+    [
+      '-e',
+      `const http=require('node:http'),fs=require('node:fs'),path=require('node:path');const root=process.argv[1];const server=http.createServer((req,res)=>{const file=path.join(root,req.url);if(!fs.existsSync(file)){res.writeHead(404).end();return}res.end(fs.readFileSync(file))});server.listen(0,'127.0.0.1',()=>console.log(server.address().port));`,
+      registry,
+    ],
+    { stdio: ['ignore', 'pipe', 'inherit'] }
+  );
+  let output = '';
+  for await (const chunk of server.stdout) {
+    output += chunk;
+    if (output.includes('\n')) break;
+  }
+  return { server, url: `http://127.0.0.1:${output.trim()}` };
+}
+
+function run(project, url, args) {
+  return spawnSync(process.execPath, [cli, ...args, '--cwd', project, '--registry', url, '--yes'], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+}
+
+function lock(project) {
+  return JSON.parse(fs.readFileSync(path.join(project, 'panelui-lock.json'), 'utf8'));
+}
+
+test('named updates prune only digest-matching dependencies orphaned by every root', async () => {
+  const registry = path.join(root, 'shared-registry');
+  fs.mkdirSync(registry);
+  item(registry, 'alpha', 'ui/alpha.ts', ['shared', 'former']);
+  item(registry, 'beta', 'ui/beta.ts', ['shared']);
+  item(registry, 'shared', 'lib/shared.ts');
+  item(registry, 'former', 'lib/former.ts');
+  item(registry, 'gamma', 'ui/gamma.ts', ['edited']);
+  item(registry, 'edited', 'lib/edited.ts');
+  const app = project('shared-project');
+  const { server, url } = await registryServer(registry);
+
+  try {
+    assert.equal(run(app, url, ['add', 'alpha', 'beta', 'gamma']).status, 0);
+    assert.deepEqual(lock(app).roots, {
+      alpha: ['alpha', 'shared', 'former'],
+      beta: ['beta', 'shared'],
+      gamma: ['gamma', 'edited'],
+    });
+    assert.deepEqual(lock(app).legacyFiles, []);
+    const transitiveOnly = run(app, url, ['update', 'shared']);
+    assert.equal(transitiveOnly.status, 1);
+    assert.match(`${transitiveOnly.stdout}${transitiveOnly.stderr}`, /Not tracked as a requested root/);
+
+    item(registry, 'alpha', 'ui/alpha.ts');
+    const beforePreview = fs.readFileSync(path.join(app, 'panelui-lock.json'), 'utf8');
+    assert.equal(run(app, url, ['update', 'alpha', '--dry-run']).status, 1);
+    assert.equal(fs.readFileSync(path.join(app, 'panelui-lock.json'), 'utf8'), beforePreview);
+    assert.equal(fs.existsSync(path.join(app, 'lib/former.ts')), true);
+
+    assert.equal(run(app, url, ['update', 'alpha']).status, 0);
+    assert.equal(fs.existsSync(path.join(app, 'lib/former.ts')), false);
+    assert.equal(fs.existsSync(path.join(app, 'lib/shared.ts')), true);
+    assert.deepEqual(lock(app).roots.alpha, ['alpha']);
+
+    item(registry, 'beta', 'ui/beta.ts');
+    assert.equal(run(app, url, ['update', 'beta']).status, 0);
+    assert.equal(fs.existsSync(path.join(app, 'lib/shared.ts')), false);
+
+    fs.writeFileSync(path.join(app, 'lib/edited.ts'), 'local edit\n');
+    item(registry, 'gamma', 'ui/gamma.ts');
+    const conflicted = run(app, url, ['update', 'gamma']);
+    assert.equal(conflicted.status, 1, `${conflicted.stdout}${conflicted.stderr}`);
+    assert.match(conflicted.stdout, /lib\/edited\.ts.*modified/);
+    assert.equal(fs.readFileSync(path.join(app, 'lib/edited.ts'), 'utf8'), 'local edit\n');
+    assert.deepEqual(lock(app).roots.gamma, ['gamma']);
+    assert.equal(run(app, url, ['update', 'gamma']).status, 1);
+  } finally {
+    server.kill();
+  }
+});
+
+test('v1 locks stay conservative until add records an explicit root closure', async () => {
+  const registry = path.join(root, 'legacy-registry');
+  fs.mkdirSync(registry);
+  item(registry, 'legacy-root', 'ui/legacy.ts', ['legacy-dep']);
+  item(registry, 'legacy-dep', 'lib/legacy-dep.ts');
+  const app = project('legacy-project');
+  fs.mkdirSync(path.join(app, 'components/ui'), { recursive: true });
+  fs.mkdirSync(path.join(app, 'lib'));
+  fs.writeFileSync(path.join(app, 'components/ui/legacy.ts'), 'legacy-root\n');
+  fs.writeFileSync(path.join(app, 'lib/legacy-dep.ts'), 'legacy-dep\n');
+  writeLock(app, {
+    version: 1,
+    files: {
+      'components/ui/legacy.ts': { item: 'legacy-root', digest: digest('legacy-root\n') },
+      'lib/legacy-dep.ts': { item: 'legacy-dep', digest: digest('legacy-dep\n') },
+    },
+  });
+  const { server, url } = await registryServer(registry);
+
+  try {
+    const conservative = run(app, url, ['update', 'legacy-root']);
+    assert.equal(conservative.status, 0, `${conservative.stdout}${conservative.stderr}`);
+    assert.match(conservative.stdout, /v1 cannot prune former dependencies safely/);
+    assert.equal(lock(app).version, 1);
+
+    assert.equal(run(app, url, ['add', 'legacy-root']).status, 0);
+    assert.equal(lock(app).version, 2);
+    assert.deepEqual(lock(app).roots, { 'legacy-root': ['legacy-root', 'legacy-dep'] });
+    assert.deepEqual(lock(app).legacyFiles, []);
+
+    item(registry, 'legacy-root', 'ui/legacy.ts');
+    assert.equal(run(app, url, ['update', 'legacy-root']).status, 0);
+    assert.equal(fs.existsSync(path.join(app, 'lib/legacy-dep.ts')), false);
+  } finally {
+    server.kill();
+  }
+});

--- a/packages/cli/test/root-closures.test.mjs
+++ b/packages/cli/test/root-closures.test.mjs
@@ -150,3 +150,54 @@ test('v1 locks stay conservative until add records an explicit root closure', as
     server.kill();
   }
 });
+
+test('migrating to v2 keeps updating components installed before the lock had roots', async () => {
+  const registry = path.join(root, 'adopted-registry');
+  fs.mkdirSync(registry);
+  item(registry, 'adopted', 'ui/adopted.ts');
+  item(registry, 'newcomer', 'ui/newcomer.ts');
+  const app = project('adopted-project');
+  fs.mkdirSync(path.join(app, 'components/ui'), { recursive: true });
+  fs.writeFileSync(path.join(app, 'components/ui/adopted.ts'), 'adopted\n');
+  writeLock(app, {
+    version: 1,
+    files: { 'components/ui/adopted.ts': { item: 'adopted', digest: digest('adopted\n') } },
+  });
+  const { server, url } = await registryServer(registry);
+
+  try {
+    // Adding an unrelated component is what migrates the lock to v2.
+    assert.equal(run(app, url, ['add', 'newcomer']).status, 0);
+    assert.deepEqual(lock(app).roots, { newcomer: ['newcomer'] });
+    assert.deepEqual(lock(app).legacyFiles, ['components/ui/adopted.ts']);
+
+    // The component that predates the migration is still updated by name...
+    fs.writeFileSync(
+      path.join(registry, 'adopted.json'),
+      JSON.stringify({
+        name: 'adopted',
+        files: [{ path: 'ui/adopted.ts', content: 'adopted v2\n' }],
+        registryDependencies: [],
+      })
+    );
+    const named = run(app, url, ['update', 'adopted']);
+    assert.equal(named.status, 0, `${named.stdout}${named.stderr}`);
+    assert.equal(fs.readFileSync(path.join(app, 'components/ui/adopted.ts'), 'utf8'), 'adopted v2\n');
+
+    // ...and by a bare update, which must not quietly skip it.
+    fs.writeFileSync(
+      path.join(registry, 'adopted.json'),
+      JSON.stringify({
+        name: 'adopted',
+        files: [{ path: 'ui/adopted.ts', content: 'adopted v3\n' }],
+        registryDependencies: [],
+      })
+    );
+    const bare = run(app, url, ['update']);
+    assert.equal(bare.status, 0, `${bare.stdout}${bare.stderr}`);
+    assert.match(bare.stdout, /adopted/);
+    assert.equal(fs.readFileSync(path.join(app, 'components/ui/adopted.ts'), 'utf8'), 'adopted v3\n');
+  } finally {
+    server.kill();
+  }
+});

--- a/packages/cli/test/safe-update.test.mjs
+++ b/packages/cli/test/safe-update.test.mjs
@@ -75,7 +75,8 @@ test('update writes only digest-matching files and reports modified files', asyn
     const added = run(['add', 'card', ...common]);
     assert.equal(added.status, 0, `${added.stdout}${added.stderr}`);
     const lock = JSON.parse(fs.readFileSync(path.join(project, 'panelui-lock.json'), 'utf8'));
-    assert.equal(lock.version, 1);
+    assert.equal(lock.version, 2);
+    assert.deepEqual(lock.roots, { card: ['card'] });
     assert.equal(lock.files['components/ui/card.tsx'].item, 'card');
     const unchanged = run(['update', ...common]);
     assert.equal(unchanged.status, 0, `${unchanged.stdout}${unchanged.stderr}`);


### PR DESCRIPTION
## What this changes

Upgrades `panelui-lock.json` to a backward-compatible v2 that records each explicitly requested root and its registry dependency closure, enabling safe orphan pruning during named updates.

## Why

The v1 lock only mapped files to items. After a registry dependency edge changed, the CLI could not know whether a former transitive item was still shared by another requested component, so subset updates had to leave orphans indefinitely.

## Type of change

- [ ] Bug fix
- [ ] New component
- [x] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [ ] Documentation only
- [ ] Internal: refactor, tooling, CI

## How it was tested

- [ ] iOS
- [ ] Android
- [ ] Light and dark themes
- [x] Focused root-closure/update tests — 5/5
- [x] Full CLI suite — 66/66
- [x] Root library build — 167 files
- [x] CLI package dry-run

## Screenshots or recording

Not applicable; this changes CLI state and update behavior.

## Checklist

- [x] PanelUI typecheck passes
- [x] `npm run build` passes
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] CLI README updated with v1 migration guidance
- [x] Check/dry-run remain read-only

## Notes for the reviewer

V1 locks stay readable and conservative. Re-running `add <root>` records an explicit closure; locally edited legacy/orphan files are never deleted. Shared dependencies remain until no requested root needs them, and named updates reject transitive-only names.
