### PR TITLE
test(docs): add axe browser smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Build documentation
         run: npm run build --workspace=docs
 
+      - name: Install accessibility smoke browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Browser accessibility smoke
+        run: npm run test:a11y:browser
+
       - name: Verify packed CLI consumers
         run: npm run verify:cli-packages
 

--- a/apps/docs/app/layout.config.tsx
+++ b/apps/docs/app/layout.config.tsx
@@ -61,8 +61,12 @@ export const baseOptions: BaseLayoutProps = {
     },
     {
       // Star count where available, a bare icon while the repo is private.
-      type: 'custom',
-      children: <GithubStars />,
+      // Let Fumadocs own the anchor and list item. A custom item is inserted
+      // directly under its desktop ul, producing invalid list markup.
+      type: 'button',
+      text: <GithubStars />,
+      url: site.repo,
+      external: true,
       secondary: true,
     },
     {

--- a/apps/docs/components/github-stars.tsx
+++ b/apps/docs/components/github-stars.tsx
@@ -1,12 +1,10 @@
-import Link from 'next/link';
 import { fetchRepositoryInfo } from 'fumadocs-ui/components/github-info';
-import { site } from '@/lib/site';
 
 const OWNER = 'panel-ui';
 const REPO = 'PanelUI';
 
 /**
- * GitHub link with a star count.
+ * Contents for the GitHub navigation link, with a star count.
  *
  * The count is best-effort: `fetchRepositoryInfo` calls the public GitHub API,
  * which 404s while the repository is private. Rather than break the navbar,
@@ -38,22 +36,17 @@ export async function GithubStars() {
   }
 
   return (
-    <Link
-      href={site.repo}
-      target="_blank"
-      rel="noreferrer noopener"
-      aria-label={
-        stars === null ? 'GitHub repository' : `GitHub repository, ${stars} stars`
-      }
-      className="inline-flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
-    >
+    <>
       <svg viewBox="0 0 24 24" className="size-4 fill-current" aria-hidden="true">
         <path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.6-1.4-1.4-1.8-1.4-1.8-1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.7-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.4 1.2-3.2 0-.4-.5-1.6.2-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.7 1.6.2 2.8.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3" />
       </svg>
+      <span className="sr-only">GitHub repository</span>
       {stars === null ? null : (
-        <span className="tabular-nums">{formatStars(stars)}</span>
+        <span className="tabular-nums" aria-label={`${stars} stars`}>
+          {formatStars(stars)}
+        </span>
       )}
-    </Link>
+    </>
   );
 }
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,6 +9,7 @@
     "postinstall": "fumadocs-mdx",
     "typecheck": "tsc --noEmit",
     "test": "node --experimental-strip-types --test test/*.test.mjs",
+    "test:a11y:browser": "node test/accessibility-smoke.mjs",
     "docs:generate": "node scripts/extract.mjs && node scripts/gen.mjs && node scripts/extract-icons.mjs && node scripts/build-registry.mjs && node scripts/build-api-reference.mjs && node scripts/build-skill.mjs && node scripts/build-skill-assets.mjs && node ../../scripts/theme-manifest.mjs && node ../../scripts/catalogue-manifest.mjs",
     "registry:build": "node scripts/build-registry.mjs",
     "prebuild": "node scripts/extract-icons.mjs && node scripts/build-registry.mjs && node scripts/build-api-reference.mjs --check && node scripts/build-skill.mjs && node scripts/build-skill-assets.mjs"
@@ -39,11 +40,13 @@
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/mdx": "^2.0.13",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
+    "playwright": "^1.62.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.3.3",
     "tw-animate-css": "^1.4.0",

--- a/apps/docs/test/accessibility-smoke-contract.test.mjs
+++ b/apps/docs/test/accessibility-smoke-contract.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const root = path.resolve(import.meta.dirname, '../../..');
+const source = fs.readFileSync(path.join(import.meta.dirname, 'accessibility-smoke.mjs'), 'utf8');
+const workflow = fs.readFileSync(path.join(root, '.github/workflows/ci.yml'), 'utf8');
+const rootPackage = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+
+test('the browser smoke stays bounded to representative production routes', () => {
+  assert.match(source, /const ROUTES = \['\/', '\/docs', '\/docs\/components\/button'\]/);
+  assert.match(source, /withTags\(WCAG_TAGS\)/);
+  assert.match(source, /results\.violations\.length/);
+});
+
+test('CI builds docs, installs only Chromium, and runs the browser gate in order', () => {
+  const build = workflow.indexOf('run: npm run build --workspace=docs');
+  const install = workflow.indexOf('run: npx playwright install --with-deps chromium');
+  const smoke = workflow.indexOf('run: npm run test:a11y:browser');
+  assert.ok(build >= 0 && build < install && install < smoke);
+  assert.equal(rootPackage.scripts['test:a11y:browser'], 'npm run test:a11y:browser --workspace=docs');
+});

--- a/apps/docs/test/accessibility-smoke.mjs
+++ b/apps/docs/test/accessibility-smoke.mjs
@@ -1,0 +1,104 @@
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import net from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import AxeBuilder from '@axe-core/playwright';
+import { chromium } from 'playwright';
+
+const require = createRequire(import.meta.url);
+const DOCS_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ROUTES = ['/', '/docs', '/docs/components/button'];
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'];
+
+function availablePort() {
+  return new Promise((resolve, reject) => {
+    const socket = net.createServer();
+    socket.once('error', reject);
+    socket.listen(0, '127.0.0.1', () => {
+      const address = socket.address();
+      socket.close(() => resolve(address.port));
+    });
+  });
+}
+
+async function waitForServer(url, server) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (server.exitCode !== null) throw new Error(`Docs server exited with ${server.exitCode}`);
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(1_000) });
+      if (response.ok) return;
+    } catch {
+      // The production server is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('Docs server did not become ready within 30 seconds');
+}
+
+function formatViolations(route, violations) {
+  const details = violations.flatMap((violation) => [
+    `${route}: ${violation.id} (${violation.impact ?? 'unknown'}) — ${violation.help}`,
+    ...violation.nodes.map((node) => `  ${node.target.join(' ')}: ${node.failureSummary}`),
+  ]);
+  return details.join('\n');
+}
+
+async function stopServer(server) {
+  if (server.exitCode !== null) return;
+  server.kill('SIGTERM');
+  await Promise.race([
+    new Promise((resolve) => server.once('exit', resolve)),
+    new Promise((resolve) => setTimeout(resolve, 5_000)),
+  ]);
+  if (server.exitCode === null) server.kill('SIGKILL');
+}
+
+async function run() {
+  const port = await availablePort();
+  const origin = `http://127.0.0.1:${port}`;
+  const logs = [];
+  const server = spawn(
+    process.execPath,
+    [require.resolve('next/dist/bin/next'), 'start', '--hostname', '127.0.0.1', '--port', String(port)],
+    { cwd: DOCS_ROOT, env: { ...process.env, NODE_ENV: 'production' }, stdio: ['ignore', 'pipe', 'pipe'] }
+  );
+  for (const stream of [server.stdout, server.stderr]) {
+    stream.on('data', (chunk) => logs.push(chunk.toString()));
+  }
+
+  let browser;
+  try {
+    await waitForServer(origin, server);
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({ reducedMotion: 'reduce' });
+    const page = await context.newPage();
+    const failures = [];
+
+    for (const route of ROUTES) {
+      const response = await page.goto(`${origin}${route}`, { waitUntil: 'domcontentloaded' });
+      if (!response?.ok()) throw new Error(`${route} returned HTTP ${response?.status() ?? 'unknown'}`);
+      await page.locator('h1').first().waitFor({ state: 'visible' });
+      await page.evaluate(() => document.fonts.ready);
+      const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+      if (results.violations.length) failures.push(formatViolations(route, results.violations));
+      else console.log(`✓ ${route}`);
+    }
+
+    if (failures.length) throw new Error(`Accessibility violations:\n${failures.join('\n')}`);
+    console.log(`Docs accessibility smoke: ${ROUTES.length} routes, Chromium, WCAG 2 A/AA`);
+  } catch (error) {
+    const serverLog = logs.join('').trim();
+    if (serverLog) console.error(`Docs server output:\n${serverLog}`);
+    throw error;
+  } finally {
+    await browser?.close();
+    await stopServer(server);
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/docs/accessibility-release-checklist.md
+++ b/docs/accessibility-release-checklist.md
@@ -58,12 +58,21 @@ overlap. Target-size reference: `packages/panelui/test/core-target-sizes.test.mj
 Automated contract references: `apps/docs/test/composite-keyboard.test.mjs` and
 `packages/panelui/test/context-menu-invocation.test.mjs`.
 
+## Browser automation — docs
+
+After the production docs build, run `npm run test:a11y:browser`. It starts that
+build locally and runs axe in headless Chromium against the home page, docs
+shell, and Button guide using WCAG 2.0, 2.1, and 2.2 A/AA rules. This bounded
+smoke catches deterministic markup regressions; it is not a site-wide crawl,
+an assistive-technology test, or WCAG certification.
+
 ## Sign-off
 
 - [ ] `npm run test:a11y` passes at the release commit.
 - [ ] VoiceOver scenarios pass; device/build evidence is linked.
 - [ ] TalkBack scenarios pass; device/build evidence is linked.
 - [ ] Keyboard scenarios pass in a supported browser.
+- [ ] The docs browser accessibility smoke passes.
 - [ ] Failures are filed with component, platform, build, steps, expected
       announcement/focus, and actual announcement/focus. No claim of full WCAG
       or device coverage is made from this checklist alone.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,11 +36,13 @@
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.13.0",
         "@tailwindcss/postcss": "^4.3.3",
         "@types/mdx": "^2.0.13",
         "@types/node": "^24.0.0",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
+        "playwright": "^1.62.1",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.3.3",
         "tw-animate-css": "^1.4.0",
@@ -517,6 +519,19 @@
       "integrity": "sha512-9kU2sUE38FZEGG7l3hamYMBieLYEJh2L1mrYD2eXpT+78EnQSV1bhjxJhnxGBMSTbtwpBSDNSK+K60WvaI/DTQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -7326,6 +7341,16 @@
         "astring": "bin/astring"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
@@ -9682,6 +9707,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -13483,6 +13523,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "test:a11y": "node scripts/accessibility-gate.mjs",
+    "test:a11y:browser": "npm run test:a11y:browser --workspace=docs",
     "test:cli": "node --test packages/cli/test/*.test.mjs",
     "verify:cli-packages": "node scripts/verify-cli-packages.mjs",
     "example": "npm run start --workspace=example",


### PR DESCRIPTION
## What this changes

Adds a bounded axe/Chromium smoke over three representative production docs routes and fixes invalid navbar list markup exposed by the first scan.

## Why

The accessibility release gate covered source contracts and manual scenarios but did not inspect rendered web markup. Invalid composition inside Fumadocs chrome could therefore ship while all static checks passed.

## Type of change

- [x] Bug fix
- [ ] New component
- [ ] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [ ] Documentation only
- [ ] Internal: refactor, tooling, CI

## How it was tested

- [ ] iOS
- [ ] Android
- [x] Desktop Chromium production markup
- [x] Browser smoke — 3/3 routes
- [x] Focused contracts — 2/2
- [x] Root suite — 211/211; existing a11y gate — 48/48
- [x] Docs production build — 319 static pages

## Screenshots or recording

Not applicable; the GitHub navigation item retains its icon, dynamic star display, destination, and accessible naming.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes (167 files)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Accessibility checklist documents exact automated scope and exclusions
- [x] CI installs only Chromium

## Notes for the reviewer

Coverage is intentionally limited to `/`, `/docs`, and `/docs/components/button`, using WCAG 2.0/2.1/2.2 A/AA axe tags. This is not a crawl, screen-reader test, or WCAG certification. The markup fix lets Fumadocs own the navbar anchor/list item rather than inserting a custom anchor directly beneath its `ul`.
