### PR TITLE
fix(release): validate version and tag parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check release version and tag parity
+        run: npm run release:check
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16308,7 +16308,7 @@
     },
     "packages/cli": {
       "name": "panelui-cli",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "bin": {
         "panelui-cli": "bin/panelui.mjs"
@@ -16318,10 +16318,10 @@
       }
     },
     "packages/create-panelui-app": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "panelui-cli": "^0.4.0"
+        "panelui-cli": "^0.5.0"
       },
       "bin": {
         "create-panelui-app": "index.mjs"
@@ -16332,7 +16332,7 @@
     },
     "packages/panelui": {
       "name": "panelui-native",
-      "version": "0.66.1",
+      "version": "0.68.0",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "example:clear": "npm run start --workspace=example -- --clear",
     "catalogue:check": "node scripts/catalogue-manifest.mjs --check",
     "catalogue:generate": "node scripts/catalogue-manifest.mjs",
+    "release:check": "node scripts/release-parity.mjs",
     "themes:check": "node scripts/theme-manifest.mjs",
     "reset": "rm -rf apps/example/.expo apps/example/node_modules/.cache node_modules/.cache $TMPDIR/metro-* $TMPDIR/haste-map-* 2>/dev/null; echo \"caches cleared\"",
     "docs": "npm run dev --workspace=docs",

--- a/scripts/release-parity.mjs
+++ b/scripts/release-parity.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+export const RELEASE_PACKAGES = Object.freeze([
+  {
+    directory: 'packages/panelui',
+    name: 'panelui-native',
+    tagPrefix: 'v',
+    changelog: true,
+  },
+  {
+    directory: 'packages/cli',
+    name: 'panelui-cli',
+    tagPrefix: 'cli-v',
+  },
+  {
+    directory: 'packages/create-panelui-app',
+    name: 'create-panelui-app',
+    tagPrefix: 'create-v',
+  },
+]);
+
+export function releaseTarget(tag) {
+  const target = RELEASE_PACKAGES.find(({ tagPrefix }) => tag.startsWith(tagPrefix));
+  if (!target) return null;
+  const version = tag.slice(target.tagPrefix.length);
+  return VERSION.test(version) ? { ...target, version } : null;
+}
+
+function sameRecord(left, right) {
+  const normalize = (record) =>
+    Object.fromEntries(Object.entries(record ?? {}).sort(([a], [b]) => a.localeCompare(b)));
+  return JSON.stringify(normalize(left)) === JSON.stringify(normalize(right));
+}
+
+export function validateReleaseParity(read) {
+  const errors = [];
+  const json = (file) => JSON.parse(read(file));
+  const lock = json('package-lock.json');
+  const hub = read('apps/docs/content/docs/upgrading.mdx');
+  const changelog = read('CHANGELOG.md');
+  const ciWorkflow = read('.github/workflows/ci.yml');
+  const libraryWorkflow = read('.github/workflows/publish.yml');
+  const cliWorkflow = read('.github/workflows/publish-cli.yml');
+  const docsWorkflow = read('.github/workflows/deploy-docs.yml');
+  const dependencyFields = [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies',
+  ];
+
+  for (const target of RELEASE_PACKAGES) {
+    const source = `${target.directory}/package.json`;
+    const manifest = json(source);
+    const locked = lock.packages?.[target.directory];
+    if (manifest.name !== target.name) {
+      errors.push(`${source}: expected package name ${target.name}, received ${manifest.name}`);
+    }
+    if (!VERSION.test(manifest.version)) {
+      errors.push(`${source}: invalid release version ${manifest.version}`);
+    }
+    if (!locked) {
+      errors.push(`package-lock.json: missing workspace ${target.directory}`);
+    } else {
+      if (locked.version !== manifest.version) {
+        errors.push(
+          `package-lock.json: ${target.directory} is ${locked.version}, manifest is ${manifest.version}`,
+        );
+      }
+      for (const field of dependencyFields) {
+        if (!sameRecord(locked[field], manifest[field])) {
+          errors.push(`package-lock.json: ${target.directory} ${field} drifted from its manifest`);
+        }
+      }
+    }
+
+    const escapedName = target.name.replaceAll('-', '\\-');
+    const escapedVersion = manifest.version.replaceAll('.', '\\.');
+    const row = new RegExp(
+      `^\\| \`${escapedName}\`\\s+\\| \`${escapedVersion}\`\\s+\\|`,
+      'gm',
+    );
+    if ((hub.match(row) ?? []).length !== 1) {
+      errors.push(`upgrading.mdx: expected one ${target.name} ${manifest.version} row`);
+    }
+    const npmUrl = `https://www.npmjs.com/package/${target.name}/v/${manifest.version}`;
+    if (!hub.includes(npmUrl)) errors.push(`upgrading.mdx: missing ${npmUrl}`);
+    const sourceUrl = `https://github.com/panel-ui/PanelUI/blob/main/${source}`;
+    if (!hub.includes(sourceUrl)) errors.push(`upgrading.mdx: missing ${sourceUrl}`);
+
+    if (target.changelog) {
+      const current = changelog.match(/^## \[([^\]]+)\]/m)?.[1];
+      if (current !== manifest.version) {
+        errors.push(`CHANGELOG.md: current release is ${current}, manifest is ${manifest.version}`);
+      }
+    }
+  }
+
+  const workflowContracts = [
+    [ciWorkflow, 'run: npm run release:check', 'release parity CI gate'],
+    [libraryWorkflow, "startsWith(github.ref_name, 'v')", 'library tag filter'],
+    [libraryWorkflow, '${GITHUB_REF_NAME#v}', 'library tag parser'],
+    [docsWorkflow, "startsWith(github.ref_name, 'v')", 'docs release tag filter'],
+    [
+      cliWorkflow,
+      'cli-v*)    dir=packages/cli;                name=panelui-cli;        version="${tag#cli-v}" ;;',
+      'CLI tag parser',
+    ],
+    [
+      cliWorkflow,
+      'create-v*) dir=packages/create-panelui-app; name=create-panelui-app; version="${tag#create-v}" ;;',
+      'create-app tag parser',
+    ],
+  ];
+  for (const [workflow, contract, label] of workflowContracts) {
+    if (!workflow.includes(contract)) errors.push(`workflow: missing ${label} (${contract})`);
+  }
+
+  return errors;
+}
+
+export function checkReleaseParity(root = ROOT) {
+  const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
+  const errors = validateReleaseParity(read);
+  if (errors.length) throw new Error(`Release parity failed:\n${errors.join('\n')}`);
+  const versions = RELEASE_PACKAGES.map(({ directory, name, tagPrefix }) => {
+    const version = JSON.parse(read(`${directory}/package.json`)).version;
+    return `${tagPrefix}${version} (${name})`;
+  });
+  console.log(`Verified release parity: ${versions.join(', ')}.`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    checkReleaseParity();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/test/release-parity.test.mjs
+++ b/test/release-parity.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  checkReleaseParity,
+  releaseTarget,
+  validateReleaseParity,
+} from '../scripts/release-parity.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const FILES = [
+  'package-lock.json',
+  'CHANGELOG.md',
+  'apps/docs/content/docs/upgrading.mdx',
+  '.github/workflows/ci.yml',
+  '.github/workflows/publish.yml',
+  '.github/workflows/publish-cli.yml',
+  '.github/workflows/deploy-docs.yml',
+  'packages/panelui/package.json',
+  'packages/cli/package.json',
+  'packages/create-panelui-app/package.json',
+];
+
+function fixture() {
+  return new Map(
+    FILES.map((file) => [file, fs.readFileSync(path.join(ROOT, file), 'utf8')]),
+  );
+}
+
+test('current manifests, lock, changelog, docs, and workflows agree', () => {
+  assert.doesNotThrow(() => checkReleaseParity(ROOT));
+  assert.deepEqual(
+    ['v0.68.0', 'cli-v0.5.0', 'create-v0.2.1'].map((tag) => {
+      const target = releaseTarget(tag);
+      return [target?.name, target?.version, target?.tagPrefix];
+    }),
+    [
+      ['panelui-native', '0.68.0', 'v'],
+      ['panelui-cli', '0.5.0', 'cli-v'],
+      ['create-panelui-app', '0.2.1', 'create-v'],
+    ],
+  );
+  assert.equal(releaseTarget('docs-v1.0.0'), null);
+  assert.equal(releaseTarget('vnot-a-version'), null);
+});
+
+test('a future manifest bump identifies every release artifact to update', () => {
+  const files = fixture();
+  const manifest = JSON.parse(files.get('packages/panelui/package.json'));
+  manifest.version = '0.69.0';
+  files.set('packages/panelui/package.json', JSON.stringify(manifest));
+
+  const errors = validateReleaseParity((file) => files.get(file));
+  assert.ok(errors.some((error) => error.includes('manifest is 0.69.0')));
+  assert.ok(errors.some((error) => error.includes('panelui-native 0.69.0 row')));
+  assert.ok(errors.some((error) => error.includes('current release is 0.68.0')));
+});
+
+test('seeded lock, docs, changelog, and tag drift is aggregated', () => {
+  const files = fixture();
+  const lock = JSON.parse(files.get('package-lock.json'));
+  lock.packages['packages/panelui'].version = '0.67.0';
+  files.set('package-lock.json', JSON.stringify(lock));
+  files.set(
+    'apps/docs/content/docs/upgrading.mdx',
+    files.get('apps/docs/content/docs/upgrading.mdx').replaceAll('0.5.0', '0.4.9'),
+  );
+  files.set('CHANGELOG.md', files.get('CHANGELOG.md').replace('## [0.68.0]', '## [0.67.0]'));
+  files.set(
+    '.github/workflows/publish-cli.yml',
+    files.get('.github/workflows/publish-cli.yml').replace('cli-v*)', 'tool-v*)'),
+  );
+
+  const errors = validateReleaseParity((file) => files.get(file));
+  assert.ok(errors.some((error) => error.includes('packages/panelui is 0.67.0')));
+  assert.ok(errors.some((error) => error.includes('panelui-cli 0.5.0 row')));
+  assert.ok(errors.some((error) => error.includes('current release is 0.67.0')));
+  assert.ok(errors.some((error) => error.includes('CLI tag parser')));
+});


### PR DESCRIPTION
## What this changes

Adds an offline release parity gate across all three package manifests, workspace lock records, the library changelog, upgrade hub, and release tag parsers. It also repairs currently stale lockfile workspace versions.

## Why

The published manifests and docs were current, but `package-lock.json` still recorded panelui 0.66.1, CLI 0.4.2, create-app 0.2.0, and the old CLI dependency range. Release metadata could drift across authoritative surfaces without CI noticing.

## Type of change

- [x] Bug fix
- [ ] New component
- [ ] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [ ] Documentation only
- [ ] Internal: refactor, tooling, CI

## How it was tested

- [ ] iOS
- [ ] Android
- [ ] Light and dark themes
- [x] Focused parity tests — 6/6
- [x] Full contract suite — 212/212
- [x] Root typecheck and library build — 167 files
- [x] Docs typecheck/build — 319 static pages
- [x] Clean generated docs output

## Screenshots or recording

Not applicable; this is release metadata validation.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Validation is local and network-independent
- [x] Errors aggregate all drift instead of stopping at the first mismatch

## Notes for the reviewer

Authority is explicit: manifests own package names/versions; the lock mirrors workspace metadata; the latest changelog heading mirrors the library only; the upgrade hub carries one current row/link set per package; tag prefixes are `v`, `cli-v`, and `create-v`. Remote tag/Release existence remains a publish-time boundary.
