### PR TITLE
feat(cli): diagnose lock and version health

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -80,7 +80,10 @@ Current registries also expose `kind`, documentation `group`, and `stability` (`
 
 Audits the current project without writing files or installing packages. It checks the PanelUI
 configuration and contained paths, aliases, CSS imports and sources, exported Metro wrapper, theme,
-Uniwind ambient types, required dependencies, and statically visible `PanelUIProvider` wiring.
+Uniwind ambient types, required dependencies, lockfile health, tracked-file digests, registry
+provenance, locally installed PanelUI package versions, and statically visible `PanelUIProvider`
+wiring. Missing or locally edited tracked files request review; malformed metadata, escaping paths,
+and provably incompatible installed versions are errors. No registry request is made.
 
 ```bash
 npx panelui-cli@latest doctor
@@ -90,6 +93,9 @@ npx panelui-cli@latest --cwd ./apps/mobile doctor --json
 The human report marks confirmed errors with `✗`, warnings with `!`, and checks that need manual
 review with `?`. Confirmed errors exit with status 1; healthy, warning, and unknown-only reports exit
 with status 0. `--json` returns a versioned object with `status`, counts, and ordered `checks` for CI.
+Version checks understand exact versions, `^`, `~`, `>=`, `*`, and `latest`. Other package-manager
+specifiers are reported as unknown rather than guessed. Newer readable lock schemas are review-only
+while their common tracked-file metadata is still checked.
 
 ### `mcp`
 

--- a/packages/cli/src/doctor.mjs
+++ b/packages/cli/src/doctor.mjs
@@ -2,11 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   CANONICAL_ALIASES,
+  DEFAULT_REGISTRY,
   aliasToDir,
   projectPath,
   validateConfigPaths,
 } from "./config.mjs";
 import { BASE_DEPENDENCIES } from "./init.mjs";
+import { digest, LOCK_FILE } from "./lock.mjs";
 import { hasWrappedMetroExport } from "./patch.mjs";
 
 const check = (id, status, message) => ({ id, status, message });
@@ -22,6 +24,221 @@ function sourceFiles(root) {
   });
 }
 
+function lockDiagnostics(cwd, config, aliases) {
+  const lockFile = path.join(cwd, LOCK_FILE);
+  if (!fs.existsSync(lockFile)) {
+    const copiedRoots = Object.values(aliases)
+      .map(aliasToDir)
+      .filter((directory) => fs.existsSync(path.join(cwd, directory)))
+      .sort();
+    return [
+      check(
+        "lock",
+        copiedRoots.length ? "warning" : "ok",
+        copiedRoots.length
+          ? `lockfile is missing while copied-source directories exist: ${copiedRoots.join(", ")}`
+          : "no lockfile or copied-source directories",
+      ),
+      check("tracked-files", "ok", "no tracked files"),
+      check("registry", "ok", "no lockfile provenance to compare"),
+    ];
+  }
+
+  let lock;
+  try {
+    lock = JSON.parse(read(lockFile));
+  } catch {
+    return invalidLock("lockfile is not valid JSON");
+  }
+  if (
+    !lock ||
+    Array.isArray(lock) ||
+    !Number.isInteger(lock.version) ||
+    lock.version < 1 ||
+    !lock.files ||
+    Array.isArray(lock.files)
+  ) {
+    return invalidLock("lockfile schema is malformed");
+  }
+  const entries = Object.entries(lock.files).sort(([left], [right]) => left.localeCompare(right));
+  if (
+    !entries.every(
+      ([, entry]) => typeof entry?.item === "string" && /^sha256:[a-f0-9]{64}$/.test(entry.digest),
+    )
+  ) {
+    return invalidLock("tracked file metadata is malformed");
+  }
+  if (lock.version === 2) {
+    const rootsValid =
+      lock.roots &&
+      !Array.isArray(lock.roots) &&
+      Object.values(lock.roots).every((closure) =>
+        Array.isArray(closure) && closure.every((item) => typeof item === "string"));
+    const legacyValid = Array.isArray(lock.legacyFiles) && lock.legacyFiles.every((relative) => typeof relative === "string");
+    if (!rootsValid || !legacyValid) return invalidLock("version 2 ownership metadata is malformed");
+  }
+
+  const missing = [];
+  const changed = [];
+  const unsafe = [];
+  const realRoot = fs.realpathSync(cwd);
+  for (const [relative, entry] of entries) {
+    let file;
+    try {
+      file = projectPath(cwd, relative, "Tracked file path");
+      if (!fs.existsSync(file)) {
+        missing.push(relative);
+        continue;
+      }
+      const realFile = fs.realpathSync(file);
+      const fromRoot = path.relative(realRoot, realFile);
+      if (!fromRoot || fromRoot.startsWith(`..${path.sep}`) || path.isAbsolute(fromRoot)) {
+        unsafe.push(relative);
+        continue;
+      }
+      if (digest(fs.readFileSync(file)) !== entry.digest)
+        changed.push(relative);
+    } catch {
+      unsafe.push(relative);
+    }
+  }
+
+  const trackedStatus = unsafe.length ? "error" : missing.length || changed.length ? "warning" : "ok";
+  const details = [
+    unsafe.length &&
+      `${unsafe.length} unsafe path${unsafe.length === 1 ? "" : "s"}`,
+    missing.length && `${missing.length} missing`,
+    changed.length && `${changed.length} locally changed`,
+  ].filter(Boolean);
+  const configuredRegistry = config.registry ?? DEFAULT_REGISTRY;
+  const provenance = typeof lock.registry !== "string"
+    ? check("registry", entries.length ? "unknown" : "ok", "lockfile registry provenance is missing")
+    : normalizeRegistry(lock.registry) === normalizeRegistry(configuredRegistry)
+        ? check("registry", "ok", `matches ${configuredRegistry}`)
+        : check(
+            "registry",
+            "warning",
+            `lockfile uses ${lock.registry}; configuration uses ${configuredRegistry}`,
+          );
+
+  return [
+    check(
+      "lock",
+      lock.version <= 2 ? "ok" : "warning",
+      lock.version <= 2
+        ? `version ${lock.version} metadata is valid (${entries.length} tracked files)`
+        : `version ${lock.version} uses a newer schema; common file metadata is readable`,
+    ),
+    check(
+      "tracked-files",
+      trackedStatus,
+      details.length
+        ? `${details.join(", ")}: ${examples([...unsafe, ...missing, ...changed])}`
+        : `${entries.length} tracked files match`,
+    ),
+    provenance,
+  ];
+}
+
+function invalidLock(message) {
+  return [
+    check("lock", "error", message),
+    check("tracked-files", "unknown", "not checked because the lockfile is unusable"),
+    check("registry", "unknown", "not checked because the lockfile is unusable"),
+  ];
+}
+
+function normalizeRegistry(value) {
+  return value.replace(/\/+$/, "");
+}
+
+function examples(files) {
+  const unique = [...new Set(files)].sort();
+  return `${unique.slice(0, 5).join(", ")}${unique.length > 5 ? ` (+${unique.length - 5} more)` : ""}`;
+}
+
+function parseVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value);
+  return match ? match.slice(1).map(Number) : null;
+}
+
+function compatible(specifier, installed) {
+  const actual = parseVersion(installed);
+  if (!actual) return null;
+  if (specifier === "*" || specifier === "latest") return true;
+  const match = /^(\^|~|>=)?(\d+\.\d+\.\d+)$/.exec(specifier);
+  if (!match) return null;
+  const wanted = parseVersion(match[2]);
+  const comparison = actual.findIndex((part, index) => part !== wanted[index]);
+  const atLeast = comparison === -1 || actual[comparison] > wanted[comparison];
+  if (!match[1]) return comparison === -1;
+  if (match[1] === ">=") return atLeast;
+  if (!atLeast || actual[0] !== wanted[0]) return false;
+  if (match[1] === "~") return actual[1] === wanted[1];
+  return (
+    wanted[0] > 0 ||
+    (actual[1] === wanted[1] && (wanted[1] > 0 || actual[2] === wanted[2]))
+  );
+}
+
+function versionDiagnostics(cwd, manifest, config) {
+  const dependencies = {
+    ...manifest.dependencies,
+    ...manifest.devDependencies,
+  };
+  const results = [];
+  if (
+    config.$schema !== undefined &&
+    config.$schema !== "https://panelui.dev/schema.json"
+  ) {
+    results.push(`configuration schema ${config.$schema} is not recognized`);
+  }
+  for (const name of ["panelui-cli", "panelui-native"]) {
+    if (!(name in dependencies)) continue;
+    const manifestFile = path.join(cwd, "node_modules", name, "package.json");
+    if (!fs.existsSync(manifestFile)) {
+      results.push(
+        `${name} ${dependencies[name]} is declared but not installed`,
+      );
+      continue;
+    }
+    try {
+      const installedManifest = JSON.parse(read(manifestFile));
+      if (installedManifest.name !== name) {
+        results.push(`${name} has an unreadable installed manifest`);
+        continue;
+      }
+      const installed = installedManifest.version;
+      const validVersion =
+        typeof installed === "string" &&
+        /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+          installed,
+        );
+      const matches = validVersion
+        ? compatible(dependencies[name], installed)
+        : false;
+      if (matches === true) continue;
+      results.push(
+        matches === false
+          ? `${name} ${installed ?? "unknown"} does not satisfy ${dependencies[name]}`
+          : `cannot prove ${name} ${installed} satisfies ${dependencies[name]}`,
+      );
+    } catch {
+      results.push(`${name} has an unreadable installed manifest`);
+    }
+  }
+  const incompatible = results.some((message) =>
+    /does not satisfy|unreadable/.test(message),
+  );
+  return check(
+    "versions",
+    incompatible ? "error" : results.length ? "unknown" : "ok",
+    results.length
+      ? results.join(", ")
+      : "locally installed PanelUI package versions are compatible",
+  );
+}
+
 export function diagnose(cwd) {
   const checks = [];
   const configFile = path.join(cwd, "panelui.json");
@@ -32,6 +249,8 @@ export function diagnose(cwd) {
       throw new Error("not an object");
     if (config.registry !== undefined && typeof config.registry !== "string")
       throw new Error("registry must be a string");
+    if (config.$schema !== undefined && typeof config.$schema !== "string")
+      throw new Error("$schema must be a string");
     if (
       config.aliases !== undefined &&
       (!config.aliases ||
@@ -152,6 +371,8 @@ export function diagnose(cwd) {
         : "required packages are present",
     ),
   );
+  checks.push(...lockDiagnostics(cwd, config, aliases));
+  checks.push(versionDiagnostics(cwd, manifest, config));
 
   const appFiles = ["app", "src/app"].flatMap((dir) =>
     sourceFiles(path.join(cwd, dir)),

--- a/packages/cli/test/doctor.test.mjs
+++ b/packages/cli/test/doctor.test.mjs
@@ -7,6 +7,7 @@ import { spawnSync } from "node:child_process";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { BASE_DEPENDENCIES } from "../src/init.mjs";
+import { digest } from "../src/lock.mjs";
 
 const cli = fileURLToPath(new URL("../bin/panelui.mjs", import.meta.url));
 const temp = () => fs.mkdtempSync(path.join(os.tmpdir(), "panelui-doctor-"));
@@ -137,4 +138,174 @@ test("unsafe configured paths are confirmed errors without escaping the project"
   const result = run(root, "--json");
   assert.equal(result.status, 1);
   assert.equal(JSON.parse(result.stdout).checks[0].id, "config");
+});
+
+test("tracked files, provenance, and compatible local versions are deterministic and read-only", () => {
+  const root = fixture();
+  write(root, "components/ui/card.tsx", "card source\n");
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, "package.json")));
+  manifest.dependencies["panelui-native"] = "^0.68.0";
+  write(root, "package.json", JSON.stringify(manifest));
+  write(
+    root,
+    "node_modules/panelui-native/package.json",
+    JSON.stringify({ name: "panelui-native", version: "0.68.2" }),
+  );
+  write(
+    root,
+    "panelui-lock.json",
+    JSON.stringify({
+      version: 1,
+      registry: "https://panelui.dev/r/",
+      files: {
+        "components/ui/card.tsx": {
+          item: "card",
+          digest: digest("card source\n"),
+        },
+      },
+    }),
+  );
+  const before = snapshot(root);
+  const first = run(root, "--json");
+  const second = run(root, "--json");
+  assert.equal(first.status, 0, first.stderr);
+  assert.equal(first.stdout, second.stdout);
+  assert.equal(snapshot(root), before);
+  const report = JSON.parse(first.stdout);
+  assert.equal(report.status, "healthy");
+  assert.deepEqual(
+    ["lock", "tracked-files", "registry", "versions"].map((id) => [
+      id,
+      report.checks.find((item) => item.id === id).status,
+    ]),
+    [
+      ["lock", "ok"],
+      ["tracked-files", "ok"],
+      ["registry", "ok"],
+      ["versions", "ok"],
+    ],
+  );
+  const v2Lock = JSON.parse(fs.readFileSync(path.join(root, "panelui-lock.json")));
+  Object.assign(v2Lock, { version: 2, roots: { card: ["card"] }, legacyFiles: [] });
+  write(root, "panelui-lock.json", JSON.stringify(v2Lock));
+  const v2Report = JSON.parse(run(root, "--json").stdout);
+  assert.equal(v2Report.status, "healthy");
+  assert.equal(v2Report.checks.find((item) => item.id === "lock").status, "ok");
+  write(
+    root,
+    "node_modules/panelui-native/package.json",
+    JSON.stringify({ name: "panelui-native", version: "0.69.0" }),
+  );
+  const incompatible = JSON.parse(run(root, "--json").stdout);
+  assert.equal(incompatible.status, "broken");
+  assert.equal(incompatible.checks.find((item) => item.id === "versions").status, "error");
+});
+
+test("local drift, missing tracked files, and registry changes request review", () => {
+  const root = fixture();
+  write(root, "components/ui/changed.tsx", "local edit\n");
+  write(
+    root,
+    "panelui-lock.json",
+    JSON.stringify({
+      version: 1,
+      registry: "https://old.panelui.dev/r",
+      files: {
+        "components/ui/changed.tsx": {
+          item: "changed",
+          digest: digest("installed\n"),
+        },
+        "components/ui/missing.tsx": {
+          item: "missing",
+          digest: digest("missing\n"),
+        },
+      },
+    }),
+  );
+  const result = run(root, "--json");
+  assert.equal(result.status, 0);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.status, "review");
+  assert.match(
+    report.checks.find((item) => item.id === "tracked-files").message,
+    /1 missing, 1 locally changed/,
+  );
+  assert.equal(
+    report.checks.find((item) => item.id === "registry").status,
+    "warning",
+  );
+});
+
+test("malformed and escaping lock metadata is confirmed breakage without outside hashing", () => {
+  const malformed = fixture();
+  write(malformed, "panelui-lock.json", "{broken");
+  const malformedResult = run(malformed, "--json");
+  assert.equal(malformedResult.status, 1);
+  assert.equal(
+    JSON.parse(malformedResult.stdout).checks.find((item) => item.id === "lock")
+      .status,
+    "error",
+  );
+  const malformedV2 = fixture();
+  write(malformedV2, "panelui-lock.json", JSON.stringify({ version: 2, files: {}, roots: [], legacyFiles: [] }));
+  const v2Result = JSON.parse(run(malformedV2, "--json").stdout);
+  assert.equal(v2Result.status, "broken");
+  assert.match(v2Result.checks.find((item) => item.id === "lock").message, /ownership metadata/);
+
+  const escaping = fixture();
+  write(
+    escaping,
+    "panelui-lock.json",
+    JSON.stringify({
+      version: 1,
+      files: {
+        "../outside.ts": { item: "outside", digest: digest("outside\n") },
+      },
+    }),
+  );
+  const escapingResult = run(escaping, "--json");
+  assert.equal(escapingResult.status, 1);
+  assert.match(
+    JSON.parse(escapingResult.stdout).checks.find(
+      (item) => item.id === "tracked-files",
+    ).message,
+    /1 unsafe path/,
+  );
+});
+
+test("newer lock schemas and unprovable installed versions request review", () => {
+  const root = fixture();
+  write(
+    root,
+    "panelui-lock.json",
+    JSON.stringify({
+      version: 3,
+      registry: "https://panelui.dev/r",
+      files: {},
+    }),
+  );
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, "package.json")));
+  manifest.devDependencies = { "panelui-cli": "workspace:*" };
+  write(root, "package.json", JSON.stringify(manifest));
+  write(
+    root,
+    "node_modules/panelui-cli/package.json",
+    JSON.stringify({ name: "panelui-cli", version: "0.5.0" }),
+  );
+  const result = run(root, "--json");
+  assert.equal(result.status, 0);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.status, "review");
+  assert.match(report.checks.find((item) => item.id === "lock").message, /newer schema/);
+  assert.equal(report.checks.find((item) => item.id === "versions").status, "unknown");
+});
+
+test("copied-source directories without a lock request review rather than claiming breakage", () => {
+  const root = fixture();
+  write(root, "components/ui/local.tsx", "export {};\n");
+  const result = run(root, "--json");
+  assert.equal(result.status, 0);
+  const lock = JSON.parse(result.stdout).checks.find((item) => item.id === "lock");
+  assert.equal(lock.status, "warning");
+  assert.match(lock.message, /lockfile is missing/);
 });


### PR DESCRIPTION
## What this changes

Extends the read-only CLI doctor with lockfile schema, tracked-file digest/containment, registry provenance, and locally installed PanelUI version diagnostics.

## Why

Doctor could report a project healthy without inspecting the safety baseline used by `update`, local copied-source drift, a registry mismatch, or a provably incompatible installed package.

## Type of change

- [ ] Bug fix
- [ ] New component
- [x] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [ ] Documentation only
- [ ] Internal: refactor, tooling, CI

## How it was tested

- [ ] iOS
- [ ] Android
- [ ] Light and dark themes
- [x] Focused doctor tests — 9/9
- [x] Full CLI suite — 69/69
- [x] Repeated JSON and whole-fixture no-mutation checks
- [x] Root library build — 167 files
- [x] CLI pack dry-run

## Screenshots or recording

Not applicable; human and JSON diagnostic contracts are asserted.

## Checklist

- [x] PanelUI typecheck passes
- [x] `npm run build` passes
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] CLI README updated
- [x] No network, mutation, or installation occurs

## Notes for the reviewer

Confirmed malformed metadata, escaping symlinks/paths, unreadable manifests, and provably incompatible versions are errors. Missing/edited files, registry drift, absent installations, unsupported ranges, and schemas above v2 request review. Official v1/v2 locks validate as healthy. Compatibility is intentionally bounded to exact, `^`, `~`, `>=`, `*`, and `latest`.
