### PR TITLE
feat(package): expand supported subpaths

### DIFF
--- a/packages/panelui/README.md
+++ b/packages/panelui/README.md
@@ -179,13 +179,20 @@ import { Button, useBreakpoint, formatTime } from 'panelui-native';
 ```
 
 For explicit module boundaries, every component and public hook also has a subpath. The public
-utilities are `cn`, `color`, and `time`:
+utilities are `cn`, `color`, and `time`. Provider, theme, and standalone foundations that do not
+expose internal helpers have explicit leaves too:
 
 ```tsx
 import { Button } from 'panelui-native/components/button';
 import { useBreakpoint } from 'panelui-native/hooks/use-breakpoint';
 import { formatTime } from 'panelui-native/utils/time';
+import { PanelUIProvider } from 'panelui-native/provider';
+import { useTheme } from 'panelui-native/theme';
+import { Scrim } from 'panelui-native/primitives/scrim';
 ```
+
+The other foundation leaves are `animated-pressable`, `keyboard-avoider`, and
+`scroll-progress` under `panelui-native/primitives/`.
 
 These imports expose the same implementations and types as the root entry. They are an
 organization and tooling boundary; they do not promise a smaller bundle without measuring your

--- a/packages/panelui/package.json
+++ b/packages/panelui/package.json
@@ -22,6 +22,36 @@
       "react-native": "./src/hooks/*.ts",
       "default": "./lib/module/hooks/*.js"
     },
+    "./provider": {
+      "types": "./lib/typescript/src/providers/panel-ui-provider.d.ts",
+      "react-native": "./src/providers/panel-ui-provider.tsx",
+      "default": "./lib/module/providers/panel-ui-provider.js"
+    },
+    "./theme": {
+      "types": "./lib/typescript/src/theme/use-theme.d.ts",
+      "react-native": "./src/theme/use-theme.ts",
+      "default": "./lib/module/theme/use-theme.js"
+    },
+    "./primitives/animated-pressable": {
+      "types": "./lib/typescript/src/primitives/animated-pressable.d.ts",
+      "react-native": "./src/primitives/animated-pressable.tsx",
+      "default": "./lib/module/primitives/animated-pressable.js"
+    },
+    "./primitives/keyboard-avoider": {
+      "types": "./lib/typescript/src/primitives/keyboard-avoider.d.ts",
+      "react-native": "./src/primitives/keyboard-avoider.tsx",
+      "default": "./lib/module/primitives/keyboard-avoider.js"
+    },
+    "./primitives/scrim": {
+      "types": "./lib/typescript/src/primitives/scrim.d.ts",
+      "react-native": "./src/primitives/scrim.tsx",
+      "default": "./lib/module/primitives/scrim.js"
+    },
+    "./primitives/scroll-progress": {
+      "types": "./lib/typescript/src/primitives/scroll-progress.d.ts",
+      "react-native": "./src/primitives/scroll-progress.tsx",
+      "default": "./lib/module/primitives/scroll-progress.js"
+    },
     "./utils/cn": {
       "types": "./lib/typescript/src/utils/cn.d.ts",
       "react-native": "./src/utils/cn.ts",
@@ -52,12 +82,14 @@
   "sideEffects": false,
   "scripts": {
     "build": "npm run clean && bob build",
-    "prepack": "npm run build && npm run verify:package",
+    "prepack": "npm run check:subpaths && npm run build && npm run verify:package",
     "test": "node --experimental-strip-types --test test/*.test.mjs",
     "benchmark:bar-chart": "node scripts/benchmark-bar-chart.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.type-tests.json",
     "clean": "rm -rf lib",
-    "verify:package": "node scripts/verify-package.mjs"
+    "verify:package": "node scripts/verify-package.mjs",
+    "generate:subpaths": "node scripts/generate-subpath-exports.mjs --write",
+    "check:subpaths": "node scripts/generate-subpath-exports.mjs"
   },
   "keywords": [
     "react-native",

--- a/packages/panelui/scripts/generate-subpath-exports.mjs
+++ b/packages/panelui/scripts/generate-subpath-exports.mjs
@@ -1,0 +1,96 @@
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const packagePath = resolve(root, 'package.json');
+const json = JSON.parse(readFileSync(packagePath, 'utf8'));
+const rootBarrel = readFileSync(resolve(root, 'src/index.ts'), 'utf8');
+const hookBarrel = readFileSync(resolve(root, 'src/hooks/index.ts'), 'utf8');
+
+const conditions = (source, output, declaration) => ({
+  types: `./lib/typescript/src/${declaration}`,
+  'react-native': `./src/${source}`,
+  default: `./lib/module/${output}`,
+});
+
+const components = readdirSync(resolve(root, 'src/components'), { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+for (const name of components) {
+  if (!existsSync(resolve(root, `src/components/${name}/index.tsx`))) {
+    throw new Error(`Component subpath has no index.tsx: ${name}`);
+  }
+  if (!rootBarrel.includes(`from './components/${name}'`)) {
+    throw new Error(`Component subpath is not root-public: ${name}`);
+  }
+}
+
+const hooks = readdirSync(resolve(root, 'src/hooks'))
+  .filter((name) => name.startsWith('use-') && name.endsWith('.ts'))
+  .map((name) => name.slice(0, -3))
+  .sort();
+for (const name of hooks) {
+  const barrel = name === 'use-direction' ? rootBarrel : hookBarrel;
+  const source = name === 'use-direction' ? './components/direction' : `./${name}`;
+  if (!barrel.includes(`from '${source}'`)) {
+    throw new Error(`Hook subpath is not root-public: ${name}`);
+  }
+}
+
+// Leaf modules are eligible only when their file is imported by the root
+// barrel and does not carry private siblings behind a wildcard.
+const leaves = [
+  ['./provider', 'providers/panel-ui-provider.tsx'],
+  ['./theme', 'theme/use-theme.ts'],
+  ['./primitives/animated-pressable', 'primitives/animated-pressable.tsx'],
+  ['./primitives/keyboard-avoider', 'primitives/keyboard-avoider.tsx'],
+  ['./primitives/scrim', 'primitives/scrim.tsx'],
+  ['./primitives/scroll-progress', 'primitives/scroll-progress.tsx'],
+  ['./utils/cn', 'utils/cn.ts'],
+  ['./utils/color', 'utils/color.ts'],
+  ['./utils/time', 'utils/time.ts'],
+];
+
+const generated = {
+  './components/*': conditions(
+    'components/*/index.tsx',
+    'components/*/index.js',
+    'components/*/index.d.ts'
+  ),
+  './hooks/*': conditions('hooks/*.ts', 'hooks/*.js', 'hooks/*.d.ts'),
+};
+
+for (const [subpath, source] of leaves) {
+  const stem = source.replace(/\.tsx?$/, '');
+  if (!existsSync(resolve(root, `src/${source}`))) throw new Error(`Missing ${source}`);
+  if (!rootBarrel.includes(`from './${stem}'`)) {
+    throw new Error(`Leaf subpath is not root-public: ${subpath}`);
+  }
+  if (generated[subpath]) throw new Error(`Duplicate subpath: ${subpath}`);
+  generated[subpath] = conditions(source, `${stem}.js`, `${stem}.d.ts`);
+}
+
+const managed = (key) =>
+  key === './components/*' ||
+  key === './hooks/*' ||
+  key === './provider' ||
+  key === './theme' ||
+  key.startsWith('./primitives/') ||
+  key.startsWith('./utils/');
+const actual = Object.fromEntries(Object.entries(json.exports).filter(([key]) => managed(key)));
+
+if (process.argv.includes('--write')) {
+  const unmanaged = Object.fromEntries(Object.entries(json.exports).filter(([key]) => !managed(key)));
+  json.exports = { '.': unmanaged['.'], ...generated };
+  for (const [key, value] of Object.entries(unmanaged)) {
+    if (key !== '.') json.exports[key] = value;
+  }
+  writeFileSync(packagePath, `${JSON.stringify(json, null, 2)}\n`);
+  console.log(`Generated ${components.length + hooks.length + leaves.length} subpaths.`);
+} else if (JSON.stringify(actual) !== JSON.stringify(generated)) {
+  throw new Error('Package subpath exports have drifted; run npm run generate:subpaths.');
+} else {
+  console.log(`Verified ${components.length + hooks.length + leaves.length} subpaths.`);
+}

--- a/packages/panelui/scripts/verify-package.mjs
+++ b/packages/panelui/scripts/verify-package.mjs
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
-import { readdirSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -8,8 +9,9 @@ const packageJson = JSON.parse(
   readFileSync(resolve(packageRoot, "package.json"), "utf8"),
 );
 const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const packRoot = mkdtempSync(join(tmpdir(), "panelui-pack-"));
 const packed = JSON.parse(
-  execFileSync(npm, ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+  execFileSync(npm, ["pack", "--json", "--ignore-scripts", "--pack-destination", packRoot], {
     cwd: packageRoot,
     encoding: "utf8",
   }),
@@ -111,6 +113,47 @@ if (forbiddenFiles.length > 0) {
   throw new Error(
     `Package contains development-only files:\n${forbiddenFiles.join("\n")}`,
   );
+}
+
+/* Resolve real package exports from a fresh unpack, not from this workspace. */
+const consumerRoot = resolve(packRoot, "consumer");
+const installed = resolve(consumerRoot, "node_modules/panelui-native");
+mkdirSync(installed, { recursive: true });
+try {
+  execFileSync("tar", [
+    "-xzf",
+    resolve(packRoot, manifest.filename),
+    "--strip-components=1",
+    "-C",
+    installed,
+  ]);
+  writeFileSync(
+    resolve(consumerRoot, "consumer.ts"),
+    [
+      "import { Meter, type MeterProps } from 'panelui-native/components/meter';",
+      "import { Planner, type PlannerProps } from 'panelui-native/components/planner';",
+      "import { PanelUIProvider } from 'panelui-native/provider';",
+      "import { Scrim } from 'panelui-native/primitives/scrim';",
+      "import { useTheme, type ThemeName } from 'panelui-native/theme';",
+      "const meter: MeterProps = { value: 1 };",
+      "const planner: PlannerProps = { entries: [] };",
+      "const theme: ThemeName = 'system';",
+      "void [Meter, Planner, PanelUIProvider, Scrim, useTheme, meter, planner, theme];",
+    ].join("\n"),
+  );
+  execFileSync(process.execPath, [
+    resolve(packageRoot, "../../node_modules/typescript/bin/tsc"),
+    "--noEmit", "--strict", "--skipLibCheck", "--module", "esnext",
+    "--moduleResolution", "bundler", resolve(consumerRoot, "consumer.ts"),
+  ], { cwd: consumerRoot, stdio: "pipe" });
+  execFileSync(process.execPath, [
+    "--input-type=module",
+    "--eval",
+    "import { formatTime } from 'panelui-native/utils/time'; if (!formatTime({ hour: 9, minute: 5 }).includes('9')) process.exit(1);",
+  ], { cwd: consumerRoot, stdio: "pipe" });
+  console.log("Verified packed subpath consumer types and runtime utility import.");
+} finally {
+  rmSync(packRoot, { recursive: true, force: true });
 }
 
 /*

--- a/packages/panelui/test/subpath-exports.test.mjs
+++ b/packages/panelui/test/subpath-exports.test.mjs
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
 import { readdir, readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
+import { promisify } from 'node:util';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const json = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'));
+const exec = promisify(execFile);
 
 test('component and hook subpaths cover every public source module', async () => {
   assert.deepEqual(json.exports['./components/*'], {
@@ -61,4 +64,28 @@ test('only root-public utilities receive subpaths', () => {
       default: `./lib/module/utils/${name}.js`,
     });
   }
+});
+
+test('reviewed provider, theme and foundation leaves have exact conditions', () => {
+  const leaves = {
+    provider: 'providers/panel-ui-provider.tsx',
+    theme: 'theme/use-theme.ts',
+    'primitives/animated-pressable': 'primitives/animated-pressable.tsx',
+    'primitives/keyboard-avoider': 'primitives/keyboard-avoider.tsx',
+    'primitives/scrim': 'primitives/scrim.tsx',
+    'primitives/scroll-progress': 'primitives/scroll-progress.tsx',
+  };
+  for (const [name, source] of Object.entries(leaves)) {
+    const stem = source.replace(/\.tsx?$/, '');
+    assert.deepEqual(json.exports[`./${name}`], {
+      types: `./lib/typescript/src/${stem}.d.ts`,
+      'react-native': `./src/${source}`,
+      default: `./lib/module/${stem}.js`,
+    });
+  }
+  assert.ok(json.exports['./components/*'], 'Meter and Planner use the component pattern');
+});
+
+test('generated subpaths are current', async () => {
+  await exec(process.execPath, ['scripts/generate-subpath-exports.mjs'], { cwd: root });
 });

--- a/packages/panelui/tsconfig.type-tests.json
+++ b/packages/panelui/tsconfig.type-tests.json
@@ -1,4 +1,14 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "panelui-native/components/*": ["./src/components/*/index.tsx"],
+      "panelui-native/hooks/*": ["./src/hooks/*.ts"],
+      "panelui-native/provider": ["./src/providers/panel-ui-provider.tsx"],
+      "panelui-native/theme": ["./src/theme/use-theme.ts"],
+      "panelui-native/primitives/*": ["./src/primitives/*.tsx"],
+      "panelui-native/utils/*": ["./src/utils/*.ts"]
+    }
+  },
   "include": ["src", "types", "type-tests"]
 }

--- a/packages/panelui/type-tests/subpath-api.type-test.ts
+++ b/packages/panelui/type-tests/subpath-api.type-test.ts
@@ -1,0 +1,26 @@
+import { Meter, type MeterProps } from 'panelui-native/components/meter';
+import { Planner, type PlannerProps } from 'panelui-native/components/planner';
+import { useBreakpoint } from 'panelui-native/hooks/use-breakpoint';
+import { PanelUIProvider, type PanelUIProviderProps } from 'panelui-native/provider';
+import { AnimatedPressable } from 'panelui-native/primitives/animated-pressable';
+import { Scrim, type ScrimProps } from 'panelui-native/primitives/scrim';
+import { useTheme, type ThemeName } from 'panelui-native/theme';
+import { cn } from 'panelui-native/utils/cn';
+import { formatTime, type TimeValue } from 'panelui-native/utils/time';
+
+const meter: typeof Meter = Meter;
+const meterProps: MeterProps = { value: 50 };
+const planner: typeof Planner = Planner;
+const plannerProps: PlannerProps = { entries: [] };
+const provider: typeof PanelUIProvider = PanelUIProvider;
+const providerProps: PanelUIProviderProps = { children: null };
+const pressable: typeof AnimatedPressable = AnimatedPressable;
+const scrim: typeof Scrim = Scrim;
+const scrimProps: ScrimProps = {};
+const theme: ThemeName = 'system';
+const time: TimeValue = { hour: 9, minute: 30 };
+
+void [
+  meter, meterProps, planner, plannerProps, provider, providerProps, pressable,
+  scrim, scrimProps, theme, useBreakpoint, useTheme, cn('p-2'), formatTime(time),
+];


### PR DESCRIPTION
## What this changes

Expands deterministic package subpaths to reviewed provider, theme, and foundation leaves, and strengthens packed-package verification with a fresh consumer compile/runtime import.

## Why

The prior pilot covered components, hooks, and three utilities but omitted stable root-public module boundaries such as the provider, theme hook/types, Scrim, and ScrollProgress. Workspace tests could also mask broken packed export paths.

## Type of change

- [ ] Bug fix
- [ ] New component
- [x] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [ ] Documentation only
- [ ] Internal: refactor, tooling, CI

## How it was tested

- [ ] iOS
- [ ] Android
- [ ] Light and dark themes
- [x] Focused subpath tests — 4/4
- [x] Full contract suite — 211/211
- [x] Root/package typecheck and library build
- [x] Real packed-package fresh-consumer compile/runtime import
- [x] Package/registry/catalogue/template gates

## Screenshots or recording

Not applicable; root API and runtime implementations are unchanged.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Subpath generation/drift check runs in prepack
- [x] No private helper modules were exposed

## Notes for the reviewer

Managed coverage grows from 122 to 128 source-derived specifiers (130 total non-root exports): 108 components, 11 standalone hooks, and 9 reviewed leaves. Provider, theme, AnimatedPressable, KeyboardAvoider, Scrim, and ScrollProgress are added; portal/text/collapse/native/icons/internal date/chart/haptics remain intentionally root-only.
