### PR TITLE
refactor(docs): adopt Next proxy convention

### DIFF
--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -39,7 +39,7 @@ function prefersMarkdown(accept: string | null): boolean {
   return markdown > 0 && markdown >= html;
 }
 
-export function middleware(request: NextRequest): NextResponse {
+export function proxy(request: NextRequest): NextResponse {
   if (!prefersMarkdown(request.headers.get('accept'))) {
     const response = NextResponse.next();
     /*

--- a/apps/docs/test/proxy-convention.test.mjs
+++ b/apps/docs/test/proxy-convention.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const docs = new URL('../', import.meta.url);
+
+test('docs use the supported Next proxy convention', async () => {
+  const source = await readFile(new URL('proxy.ts', docs), 'utf8');
+  await assert.rejects(access(new URL('middleware.ts', docs)));
+  assert.match(source, /export function proxy\(request: NextRequest\): NextResponse/);
+  assert.match(source, /matcher: \['\/', '\/docs\/:path\*'\]/);
+});


### PR DESCRIPTION
## What this changes

Renames the docs request interceptor from `middleware.ts` to Next.js 16's supported `proxy.ts` convention and renames its export from `middleware` to `proxy`. The markdown content-negotiation matcher and response behavior are unchanged.

## Why

Next.js 16.3 deprecates the middleware file convention and emitted a warning on every production build. The official migration is the exact file/export rename applied here, avoiding a future removal while the boundary is still behavior-preserving.

## Type of change

- [ ] Bug fix
- [ ] New component
- [ ] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [ ] Documentation only
- [x] Internal: refactor, tooling, CI

## How it was tested

- [ ] iOS
- [ ] Android
- [ ] Light and dark themes

The docs suite passes 23/23, the complete contract suite passes 328/328, docs typecheck passes, and the production Next 16.3 build generates 325 pages without the middleware deprecation warning.

## Screenshots or recording

Not applicable; request routing behavior is unchanged.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Animations use Reanimated on the UI thread, not the React Native `Animated` API
- [x] No hardcoded colours — everything resolves through the theme tokens
- [x] Interactive parts wire up `accessibilityRole` and mirror their state
- [x] Every new part accepts `className`

### If this touches a component's API

- [ ] Not applicable; no component API changed

### If this adds a component

- [ ] Not applicable

## Notes for the reviewer

A bounded contract test prevents reintroducing `middleware.ts` and verifies the named `proxy` export plus the existing `/` and `/docs/:path*` matcher.
