### PR TITLE
fix(cli): enforce registry transport in MCP

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -115,6 +115,8 @@ output. It reads project information from `--cwd` (the current directory by defa
 
 Registry lookups use `--registry <url>` first, then the registry in that project's `panelui.json`,
 then `https://panelui.dev/r`.
+MCP registry and documentation reads require HTTPS, including after redirects; HTTP remains available
+only for loopback registries used during local development.
 
 #### `mcp init [claude|cursor|vscode]`
 

--- a/packages/cli/src/mcp.mjs
+++ b/packages/cli/src/mcp.mjs
@@ -16,6 +16,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { DEFAULT_REGISTRY, aliasToDir, projectPath, readConfig } from './config.mjs';
 import { discover, kindOf } from './discovery.mjs';
+import { fetchJson, fetchText } from './registry.mjs';
 
 /**
  * The versions we speak, and the one we answer with otherwise.
@@ -33,13 +34,6 @@ const { default: pkg } = await import('../package.json', { with: { type: 'json' 
 /* ------------------------------------------------------------------ *
  * The registry, through the same fetch the CLI uses.
  * ------------------------------------------------------------------ */
-
-async function fetchJson(url) {
-  const response = await fetch(url);
-  if (response.status === 404) return null;
-  if (!response.ok) throw new Error(`Registry returned ${response.status} for ${url}`);
-  return response.json();
-}
 
 function registryFor(options) {
   return options.registry ?? readConfig(options.cwd)?.registry ?? DEFAULT_REGISTRY;
@@ -202,11 +196,11 @@ async function callTool(name, args, options) {
         return `"${args.name}" is not a component name. Run panelui_search_components to find one.`;
       }
       const url = `${docsOrigin(registry)}/llms.mdx/${docsPath}`;
-      const response = await fetch(url);
-      if (!response.ok) {
+      const documentation = await fetchText(url);
+      if (documentation === null) {
         return `No documentation page at ${url}. The component may be filed under charts, ai-components or form — try panelui_view_component instead.`;
       }
-      return response.text();
+      return documentation;
     }
 
     case 'panelui_get_add_command':

--- a/packages/cli/src/registry.mjs
+++ b/packages/cli/src/registry.mjs
@@ -25,7 +25,7 @@ function isLoopback(hostname) {
  * anyone on the path an edit of that source, which is why it is refused
  * anywhere but loopback.
  */
-function assertTransport(url) {
+export function assertRegistryTransport(url) {
   let parsed;
   try {
     parsed = new URL(url);
@@ -42,8 +42,8 @@ function assertTransport(url) {
   );
 }
 
-async function fetchJson(url) {
-  assertTransport(url);
+async function fetchResponse(url) {
+  assertRegistryTransport(url);
 
   let response;
   try {
@@ -55,12 +55,27 @@ async function fetchJson(url) {
     );
   }
 
+  // `fetch` follows redirects by default. Validate the effective URL as well
+  // as the requested one so an HTTPS registry cannot redirect component
+  // source onto a cleartext remote connection.
+  if (response.url) assertRegistryTransport(response.url);
+
   if (response.status === 404) return null;
   if (!response.ok) {
     fail(`Registry returned ${response.status} for ${url}.`);
   }
 
-  return response.json();
+  return response;
+}
+
+export async function fetchJson(url) {
+  const response = await fetchResponse(url);
+  return response?.json() ?? null;
+}
+
+export async function fetchText(url) {
+  const response = await fetchResponse(url);
+  return response?.text() ?? null;
 }
 
 export async function fetchIndex(registry) {

--- a/packages/cli/test/mcp-transport.test.mjs
+++ b/packages/cli/test/mcp-transport.test.mjs
@@ -11,8 +11,8 @@ function request(id, method, params) {
   return JSON.stringify({ jsonrpc: '2.0', id, method, ...(params ? { params } : {}) });
 }
 
-function run(input) {
-  const server = spawnSync(process.execPath, [cli, 'mcp'], { encoding: 'utf8', input });
+function run(input, args = []) {
+  const server = spawnSync(process.execPath, [cli, 'mcp', ...args], { encoding: 'utf8', input });
   assert.equal(server.status, 0, server.stderr);
   assert.equal(server.stderr, '');
   return server.stdout
@@ -21,6 +21,20 @@ function run(input) {
     .filter(Boolean)
     .map((line) => JSON.parse(line));
 }
+
+test('registry-reading tools reject remote cleartext before fetching', () => {
+  const [reply] = run(
+    `${request(9, 'tools/call', {
+      name: 'panelui_list_components',
+      arguments: {},
+    })}\n`,
+    ['--registry', 'http://registry.example.com/r']
+  );
+
+  assert.equal(reply.id, 9);
+  assert.equal(reply.result.isError, true);
+  assert.match(reply.result.content[0].text, /Refusing to fetch components over http/);
+});
 
 test('initialization negotiates unsupported versions to the server version', () => {
   const [reply] = run(

--- a/packages/cli/test/registry-transport.test.mjs
+++ b/packages/cli/test/registry-transport.test.mjs
@@ -29,6 +29,23 @@ test('https is allowed through to the network layer', async () => {
   });
 });
 
+test('an https registry cannot redirect source to remote cleartext', async (context) => {
+  context.mock.method(globalThis, 'fetch', async () => ({
+    url: 'http://registry.example.com/r/index.json',
+    status: 200,
+    ok: true,
+    async json() {
+      return [{ name: 'button' }];
+    },
+  }));
+
+  await assert.rejects(fetchIndex('https://registry.example.com/r'), (error) => {
+    assert.ok(error instanceof CliError);
+    assert.match(error.message, /Refusing to fetch components over http/);
+    return true;
+  });
+});
+
 test('loopback over http still works, so local development is not blocked', async () => {
   const server = http.createServer((_request, response) => {
     response.setHeader('content-type', 'application/json');


### PR DESCRIPTION
## What this changes

Makes MCP registry and documentation reads use the CLI's guarded registry transport, and revalidates the effective URL after redirects.

## Why

The regular CLI rejected remote cleartext registries, but MCP used separate raw `fetch` calls. As a result, `mcp --registry http://…` and HTTPS registries redirecting to remote HTTP could deliver source or documentation over cleartext even though registry content is treated as trusted project input.

## Type of change

- [x] Bug fix
- [ ] New component
- [ ] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [ ] Documentation only
- [ ] Internal: refactor, tooling, CI

## How it was tested

- [x] `npm run test:cli` — 78 tests passed
- [x] `npm run typecheck` — all workspaces passed after generating the docs MDX collection
- [x] `npm run build` — `panelui-native` module and declarations built
- [x] `npm pack --workspace=panelui-cli --dry-run` — package contents verified
- [x] End-to-end MCP process test confirms a remote HTTP registry is refused before a request
- [x] Redirect regression confirms an HTTPS registry cannot return source from remote HTTP

No visual behavior changed; iOS, Android, and theme checks are not applicable.

## Screenshots or recording

Not applicable — CLI transport behavior only.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Animations use Reanimated on the UI thread, not the React Native `Animated` API (not applicable)
- [x] No hardcoded colours — everything resolves through the theme tokens (not applicable)
- [x] Interactive parts wire up `accessibilityRole` and mirror their state (not applicable)
- [x] Every new part accepts `className` (not applicable)

### If this touches a component's API

Not applicable.

### If this adds a component

Not applicable.

## Notes for the reviewer

The shared helper still permits HTTP loopback registries for local development. Both the requested URL and `Response.url` are checked, so safe HTTPS redirects continue to work while final cleartext remote responses are rejected.
