### PR TITLE
fix(docs): keep Components in mobile home menu

### DIFF
--- a/apps/docs/app/(home)/layout.tsx
+++ b/apps/docs/app/(home)/layout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
-import { baseOptions } from '@/app/layout.config';
+import { homeOptions } from '@/app/layout.config';
 
 export default function Layout({ children }: { children: ReactNode }) {
-  return <HomeLayout {...baseOptions}>{children}</HomeLayout>;
+  return <HomeLayout {...homeOptions}>{children}</HomeLayout>;
 }

--- a/apps/docs/app/layout.config.tsx
+++ b/apps/docs/app/layout.config.tsx
@@ -44,9 +44,10 @@ export const baseOptions: BaseLayoutProps = {
      * of the bar. So this link lives here and not in `links` below — moving it
      * back means moving it between the two, not flipping a flag.
      *
-     * It is deliberately not in `links`, which also means it is not in
-     * `menuItems` — the mobile menu would otherwise list it twice, since the
-     * notebook sidebar already renders the page tree it points at.
+     * It is deliberately not in the shared `links`, which also means it is not
+     * in the notebook's `menuItems` — that mobile menu would otherwise list it
+     * twice, since the sidebar already renders the page tree it points at. The
+     * home-only options below restore it where no page tree exists.
      *
      * `LayoutLink`, not `next/link`: this destination is repeated by the
      * persistent chrome, and the policy behind that wrapper is what stops every
@@ -95,6 +96,26 @@ export const baseOptions: BaseLayoutProps = {
       text: 'Get started',
       url: '/docs',
       secondary: true,
+    },
+  ],
+};
+
+/**
+ * The home layout has no docs page tree, so its mobile menu needs the
+ * Components destination that `nav.children` hides below the desktop
+ * breakpoint. Keep this menu-only: adding it to `baseOptions.links` would
+ * duplicate the same destination above the notebook page tree on mobile.
+ */
+export const homeOptions: BaseLayoutProps = {
+  ...baseOptions,
+  links: [
+    ...(baseOptions.links ?? []),
+    {
+      type: 'main',
+      text: 'Components',
+      url: '/docs/components',
+      active: 'nested-url',
+      on: 'menu',
     },
   ],
 };

--- a/apps/docs/test/prefetch-policy.test.mjs
+++ b/apps/docs/test/prefetch-policy.test.mjs
@@ -40,6 +40,11 @@ test('every repeated layout instance uses the shared policy', () => {
       '<LayoutLink\n        href="/docs/components"',
     ],
     [
+      'Components mobile navigation',
+      'app/layout.config.tsx',
+      "text: 'Components',\n      url: '/docs/components',\n      active: 'nested-url',\n      on: 'menu'",
+    ],
+    [
       'Get started navigation',
       'app/layout.config.tsx',
       "text: 'Get started',\n      url: '/docs'",
@@ -53,6 +58,15 @@ test('every repeated layout instance uses the shared policy', () => {
   }
 
   assert.match(read('app/layout.tsx'), /components=\{\{ Link: LayoutLink \}\}/);
+});
+
+test('Components remains reachable on the home mobile menu without duplicating the docs tree', () => {
+  const options = read('app/layout.config.tsx');
+
+  assert.match(options, /export const homeOptions: BaseLayoutProps/);
+  assert.match(options, /on: 'menu'/);
+  assert.match(read('app/(home)/layout.tsx'), /<HomeLayout \{\.\.\.homeOptions\}>/);
+  assert.match(read('app/docs/layout.tsx'), /<DocsLayout[\s\S]*\{\.\.\.baseOptions\}/);
 });
 
 test('primary content links keep Next prefetch and link behavior passes through', () => {


### PR DESCRIPTION
## What this changes

Adds a home-layout-only, menu-only Components link so the destination remains available below the desktop breakpoint without duplicating it above the notebook docs tree.

## Why

The desktop Components link lives in `nav.children` and uses `max-lg:hidden`. After it was removed from the shared `links` array, the Fumadocs home layout had no Components entry in its mobile menu because that layout has no docs page tree to provide the destination.

## Type of change

- [x] Bug fix
- [ ] New component
- [ ] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [x] Documentation only
- [ ] Internal: refactor, tooling, CI

## How it was tested

- [ ] iOS
- [ ] Android
- [x] Light and dark themes

- `npm run test --workspace=docs` — 23/23 passing
- `npm run typecheck --workspace=docs`
- `npm run build --workspace=docs` — 325 static pages generated
- Headless Chrome at 390×844: the home mobile menu exposes one Components navigation entry after opening; the docs drawer still exposes only its page-tree entry, with no extra menu duplicate.

## Screenshots or recording

Not included; this restores a missing mobile navigation item without changing desktop presentation.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Animations use Reanimated on the UI thread, not the React Native `Animated` API
- [x] No hardcoded colours — everything resolves through the theme tokens
- [x] Interactive parts wire up `accessibilityRole` and mirror their state
- [x] Every new part accepts `className`

### If this touches a component's API

Not applicable.

### If this adds a component

Not applicable.

## Notes for the reviewer

The shared `baseOptions` intentionally remains unchanged for the notebook layout. `homeOptions` appends Components with `on: 'menu'`, so it is restored only where the home layout lacks a page tree.
