### PR TITLE
fix(cli): reject symlink path escapes

### DIFF
--- a/packages/cli/src/config.mjs
+++ b/packages/cli/src/config.mjs
@@ -135,6 +135,45 @@ export function projectPath(cwd, relativePath, label = 'Path') {
     fail(`${label} must stay inside the project.`);
   }
 
+  /*
+   * A lexical path can still leave the project through an existing symlink.
+   * Resolve the nearest path that already exists, then put the missing suffix
+   * back on that real location. This covers both a symlinked alias directory
+   * (`components -> ../shared`) and a destination that is itself a symlink,
+   * including a broken one that cannot safely be followed.
+   */
+  let ancestor = destination;
+  const suffix = [];
+  while (ancestor !== path.dirname(ancestor)) {
+    try {
+      fs.lstatSync(ancestor);
+      break;
+    } catch (error) {
+      if (error?.code !== 'ENOENT') fail(`${label} could not be inspected safely.`);
+      suffix.unshift(path.basename(ancestor));
+      ancestor = path.dirname(ancestor);
+    }
+  }
+
+  let realRoot;
+  let realAncestor;
+  try {
+    realRoot = fs.realpathSync(root);
+    realAncestor = fs.realpathSync(ancestor);
+  } catch {
+    fail(`${label} contains a broken or unreadable symbolic link.`);
+  }
+
+  const realDestination = path.resolve(realAncestor, ...suffix);
+  const realRelative = path.relative(realRoot, realDestination);
+  if (
+    !realRelative ||
+    realRelative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(realRelative)
+  ) {
+    fail(`${label} must stay inside the project, including through symbolic links.`);
+  }
+
   return destination;
 }
 

--- a/packages/cli/test/path-containment.test.mjs
+++ b/packages/cli/test/path-containment.test.mjs
@@ -64,6 +64,70 @@ test('rejects registry and configured paths that can escape a project', () => {
   }
 });
 
+test('rejects a registry destination whose existing ancestor is a symlink outside the project', () => {
+  const root = temporaryProject();
+  const cwd = path.join(root, 'project');
+  const outside = path.join(root, 'outside');
+  fs.mkdirSync(cwd);
+  fs.mkdirSync(outside);
+  fs.symlinkSync(outside, path.join(cwd, 'components'), 'dir');
+
+  const config = {
+    ...defaultConfig(),
+    aliases: { ...defaultConfig().aliases, components: '@/components' },
+  };
+
+  try {
+    assert.throws(() => targetPath(cwd, config, 'ui/button.tsx'), CliError);
+    assert.equal(fs.existsSync(path.join(outside, 'button.tsx')), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('allows a symlinked registry directory when its real target stays inside the project', () => {
+  const cwd = temporaryProject();
+  const shared = path.join(cwd, 'shared-components');
+  fs.mkdirSync(shared);
+  fs.symlinkSync(shared, path.join(cwd, 'components'), 'dir');
+
+  const config = {
+    ...defaultConfig(),
+    aliases: { ...defaultConfig().aliases, components: '@/components' },
+  };
+
+  try {
+    assert.equal(
+      targetPath(cwd, config, 'ui/button.tsx'),
+      path.join(cwd, 'components', 'button.tsx')
+    );
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('rejects a broken destination symlink instead of treating it as a missing file', () => {
+  const cwd = temporaryProject();
+  const components = path.join(cwd, 'components');
+  fs.mkdirSync(components);
+  fs.symlinkSync(
+    path.resolve(cwd, '..', 'missing-target.tsx'),
+    path.join(components, 'button.tsx'),
+    'file'
+  );
+
+  const config = {
+    ...defaultConfig(),
+    aliases: { ...defaultConfig().aliases, components: '@/components' },
+  };
+
+  try {
+    assert.throws(() => targetPath(cwd, config, 'ui/button.tsx'), CliError);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('rejects unsafe scaffold names before any project files are created', async () => {
   const cwd = temporaryProject();
   const victim = path.resolve(cwd, '..', 'victim');


### PR DESCRIPTION
## What this changes

CLI project destinations now resolve their nearest existing ancestor before any add, update, init, patch, or lockfile write can use them. Symlinks that leave the real project root and broken destination symlinks are rejected; symlinks whose targets remain inside the project continue to work.

## Why

The existing containment check was lexical. A path such as `components/button.tsx` passed validation even when `components` was a symlink to a directory outside the project, allowing a normal registry write to modify files beyond the boundary the CLI promises.

## Type of change

- [x] Bug fix
- [ ] New component
- [ ] New prop, variant, or behaviour on an existing component
- [ ] Breaking change — an existing API is renamed, removed, or behaves differently
- [ ] Documentation only
- [ ] Internal: refactor, tooling, CI

## How it was tested

- [ ] iOS
- [ ] Android
- [ ] Light and dark themes

Automated coverage and builds:

- focused path/alias tests — 9/9 passed
- `npm run test:cli` — 81/81 passed
- `npm run typecheck` — all workspaces passed
- `npm run build` — 197 library source files compiled with declarations
- `npm pack --workspace=panelui-cli --dry-run --json` — passed
- `git diff --check` — passed

The regression creates a real temporary symlink to an outside directory and proves it is rejected. It also covers safe in-project symlinks and broken destination symlinks.

## Screenshots or recording

Not applicable — filesystem safety behavior only.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Animations use Reanimated on the UI thread, not the React Native `Animated` API
- [x] No hardcoded colours — everything resolves through the theme tokens
- [x] Interactive parts wire up `accessibilityRole` and mirror their state
- [x] Every new part accepts `className`

### If this touches a component's API

- [ ] `apps/docs/scripts/meta.json` and `usage.json` are updated, with `addedIn` or `updatedIn` set
- [ ] `npm run docs:generate --workspace=docs` has been run and the generated files are committed
- [ ] A demo exists in `apps/example/src/data/components.tsx`
- [ ] Props tables read correctly — they come from the TypeScript interfaces and their JSDoc

### If this adds a component

- [ ] Exported from `packages/panelui/src/index.ts`, with its types
- [ ] Listed in `README.md` and `packages/panelui/README.md`, and the counts updated there and in `apps/docs/content/docs/index.mdx`

## Notes for the reviewer

`projectPath` remains the single shared boundary, so existing callers gain real-path containment without duplicating filesystem policy.
