### PR TITLE
test(a11y): require native journey receipts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # dependencies
 node_modules/
+accessibility-receipts/
 
 # expo
 .expo/

--- a/docs/accessibility-native-journeys.json
+++ b/docs/accessibility-native-journeys.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "platforms": ["ios", "android"],
+  "journeys": [
+    {
+      "id": "adjustable-seams",
+      "title": "Adjustable controls cross every seam once",
+      "expected": "Slider and TimePicker increment and decrement one step, announce bounded values, and never cross disabled or terminal bounds."
+    },
+    {
+      "id": "controlled-rejection",
+      "title": "Rejected controlled gestures remain owner-driven",
+      "expected": "A rejected Carousel, SplitView, or picker request settles back to the accepted prop without duplicate change or settlement announcements."
+    },
+    {
+      "id": "overlay-focus",
+      "title": "Nested overlays isolate and restore focus",
+      "expected": "Only the top overlay is traversed; closing it returns focus into its parent, and closing the parent returns focus to its opener."
+    },
+    {
+      "id": "large-text",
+      "title": "Large text preserves labels and targets",
+      "expected": "At 200% and platform maximum text, labelled controls grow without clipping and adjacent 48dp targets do not overlap."
+    },
+    {
+      "id": "swipe-dismissal",
+      "title": "Swipe dismissal completes exactly once",
+      "expected": "Drawer, sheet, toast, and swipe actions dismiss or commit once from either side of a threshold and remain operable with the screen reader active."
+    },
+    {
+      "id": "chart-exploration",
+      "title": "Structured visuals expose equivalent data",
+      "expected": "Chart, Map, and Flow data is reachable in logical order while decorative geometry stays silent and actions match touch behavior."
+    },
+    {
+      "id": "screen-reader-actions",
+      "title": "Custom actions preserve state boundaries",
+      "expected": "ContextMenu, Signature, Sortable, and disabled adjustable controls expose only currently valid actions and announce their results."
+    }
+  ]
+}

--- a/docs/accessibility-release-checklist.md
+++ b/docs/accessibility-release-checklist.md
@@ -66,6 +66,35 @@ overlap. Target-size reference: `packages/panelui/test/core-target-sizes.test.mj
 Automated contract references: `apps/docs/test/composite-keyboard.test.mjs` and
 `packages/panelui/test/context-menu-invocation.test.mjs`.
 
+## Native journey receipts
+
+The seven cross-component journeys in
+`docs/accessibility-native-journeys.json` are the bounded native release
+matrix. Run all seven on both platforms rather than selecting only the paths
+changed in the release:
+
+1. Build the exact release commit and record its SHA.
+2. Create a local template (the ignored directory prevents device evidence
+   from entering the repository):
+
+   ```sh
+   mkdir -p accessibility-receipts
+   npm run test:a11y:native -- --template > accessibility-receipts/<sha>.json
+   ```
+
+3. On VoiceOver/iOS and TalkBack/Android, fill in OS, device, build, tester,
+   date, pass/fail, and a screenshot/video/log path or link for every journey.
+4. Validate the complete receipt:
+
+   ```sh
+   npm run test:a11y:native -- --receipt accessibility-receipts/<sha>.json
+   ```
+
+The validator rejects a missing platform, missing journey, pending result,
+missing evidence, or any failed result. It does not operate the device or
+claim that typed evidence proves the observation; the named tester owns that
+release decision.
+
 ## Browser automation — docs
 
 After the production docs build, run `npm run test:a11y:browser`. It starts that
@@ -79,6 +108,7 @@ an assistive-technology test, or WCAG certification.
 - [ ] `npm run test:a11y` passes at the release commit.
 - [ ] VoiceOver scenarios pass; device/build evidence is linked.
 - [ ] TalkBack scenarios pass; device/build evidence is linked.
+- [ ] The native journey receipt passes for the exact release commit.
 - [ ] Keyboard scenarios pass in a supported browser.
 - [ ] The docs browser accessibility smoke passes.
 - [ ] Failures are filed with component, platform, build, steps, expected

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test:a11y": "node scripts/accessibility-gate.mjs",
     "test:a11y:browser": "npm run test:a11y:browser --workspace=docs",
+    "test:a11y:native": "node scripts/accessibility-native-receipt.mjs",
     "test:cli": "node --test packages/cli/test/*.test.mjs",
     "verify:cli-packages": "node scripts/verify-cli-packages.mjs",
     "example": "npm run start --workspace=example",

--- a/scripts/accessibility-gate.mjs
+++ b/scripts/accessibility-gate.mjs
@@ -96,6 +96,12 @@ export const ACCESSIBILITY_SUITES = [
     count: 4,
     anchor: 'horizontal tabs wrap and support Home and End without consuming vertical keys',
   },
+  {
+    class: 'native-journeys',
+    file: 'test/accessibility-native-journeys.test.mjs',
+    count: 3,
+    anchor: 'native accessibility journeys cover the bounded release matrix',
+  },
 ];
 
 export const REQUIRED_CLASSES = [
@@ -108,6 +114,7 @@ export const REQUIRED_CLASSES = [
   'chart-semantics',
   'accessible-actions',
   'web-keyboard',
+  'native-journeys',
 ];
 
 export const CHECKLIST = 'docs/accessibility-release-checklist.md';
@@ -116,6 +123,7 @@ export const CHECKLIST_SECTIONS = [
   '## VoiceOver — iOS',
   '## TalkBack — Android',
   '## Keyboard — web',
+  '## Native journey receipts',
   '## Sign-off',
 ];
 

--- a/scripts/accessibility-native-receipt.mjs
+++ b/scripts/accessibility-native-receipt.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+export const MANIFEST = 'docs/accessibility-native-journeys.json';
+export const REQUIRED_JOURNEYS = [
+  'adjustable-seams',
+  'controlled-rejection',
+  'overlay-focus',
+  'large-text',
+  'swipe-dismissal',
+  'chart-exploration',
+  'screen-reader-actions',
+];
+
+export function validateJourneyManifest(manifest) {
+  const errors = [];
+  if (manifest?.version !== 1) errors.push('Journey manifest version must be 1.');
+  if (JSON.stringify(manifest?.platforms) !== JSON.stringify(['ios', 'android'])) {
+    errors.push('Journey platforms must be exactly ios and android.');
+  }
+  const ids = manifest?.journeys?.map((journey) => journey.id) ?? [];
+  if (new Set(ids).size !== ids.length) errors.push('Journey ids must be unique.');
+  for (const id of REQUIRED_JOURNEYS) {
+    if (!ids.includes(id)) errors.push(`Missing required native journey: ${id}`);
+  }
+  for (const journey of manifest?.journeys ?? []) {
+    if (!journey.title?.trim() || !journey.expected?.trim()) {
+      errors.push(`Journey ${journey.id ?? '<unknown>'} needs a title and expectation.`);
+    }
+  }
+  return errors;
+}
+
+export function receiptTemplate(manifest, commit = '<release-commit>') {
+  return {
+    version: 1,
+    commit,
+    runs: manifest.platforms.map((platform) => ({
+      platform,
+      osVersion: '',
+      device: '',
+      build: '',
+      tester: '',
+      date: new Date().toISOString().slice(0, 10),
+      results: Object.fromEntries(
+        manifest.journeys.map(({ id }) => [id, { status: 'pending', evidence: '', notes: '' }]),
+      ),
+    })),
+  };
+}
+
+export function validateNativeReceipt(receipt, manifest) {
+  const errors = [];
+  if (receipt?.version !== 1) errors.push('Receipt version must be 1.');
+  if (!/^[0-9a-f]{7,40}$/.test(receipt?.commit ?? '')) {
+    errors.push('Receipt commit must be a 7-40 character Git SHA.');
+  }
+  const runs = Array.isArray(receipt?.runs) ? receipt.runs : [];
+  for (const platform of manifest.platforms) {
+    const matches = runs.filter((run) => run.platform === platform);
+    if (matches.length !== 1) {
+      errors.push(`Receipt needs exactly one ${platform} run.`);
+      continue;
+    }
+    const run = matches[0];
+    for (const field of ['osVersion', 'device', 'build', 'tester', 'date']) {
+      if (typeof run[field] !== 'string' || !run[field].trim()) {
+        errors.push(`${platform} run needs ${field}.`);
+      }
+    }
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(run.date ?? '')) {
+      errors.push(`${platform} run date must use YYYY-MM-DD.`);
+    }
+    const journeyIds = new Set(manifest.journeys.map(({ id }) => id));
+    for (const id of Object.keys(run.results ?? {})) {
+      if (!journeyIds.has(id)) errors.push(`${platform} run has unexpected journey: ${id}`);
+    }
+    for (const { id } of manifest.journeys) {
+      const result = run.results?.[id];
+      if (!['pass', 'fail'].includes(result?.status)) {
+        errors.push(`${platform}/${id} needs pass or fail status.`);
+      }
+      if (typeof result?.evidence !== 'string' || !result.evidence.trim()) {
+        errors.push(`${platform}/${id} needs linked or local evidence.`);
+      }
+      if (result?.status === 'fail') {
+        errors.push(`${platform}/${id} failed: ${result.notes || 'no notes'}`);
+      }
+    }
+  }
+  const knownPlatforms = new Set(manifest.platforms);
+  for (const run of runs) {
+    if (!knownPlatforms.has(run.platform)) errors.push(`Unexpected platform run: ${run.platform}`);
+  }
+  return errors;
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function run() {
+  const manifest = readJson(path.join(ROOT, MANIFEST));
+  const manifestErrors = validateJourneyManifest(manifest);
+  if (manifestErrors.length) throw new Error(manifestErrors.join('\n'));
+  const receiptFlag = process.argv.indexOf('--receipt');
+  if (process.argv.includes('--template')) {
+    console.log(JSON.stringify(receiptTemplate(manifest), null, 2));
+    return;
+  }
+  if (receiptFlag < 0 || !process.argv[receiptFlag + 1]) {
+    console.log(`Native accessibility journeys: ${manifest.journeys.length} journeys on iOS and Android.`);
+    console.log('Create a local receipt with: npm run test:a11y:native -- --template');
+    return;
+  }
+  const receipt = readJson(path.resolve(process.argv[receiptFlag + 1]));
+  const errors = validateNativeReceipt(receipt, manifest);
+  if (errors.length) throw new Error(errors.join('\n'));
+  console.log('Native accessibility receipt passed for iOS and Android.');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    run();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/test/accessibility-native-journeys.test.mjs
+++ b/test/accessibility-native-journeys.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  MANIFEST,
+  receiptTemplate,
+  validateJourneyManifest,
+  validateNativeReceipt,
+} from '../scripts/accessibility-native-receipt.mjs';
+
+const root = path.resolve(import.meta.dirname, '..');
+const manifest = JSON.parse(fs.readFileSync(path.join(root, MANIFEST), 'utf8'));
+
+test('native accessibility journeys cover the bounded release matrix', () => {
+  assert.deepEqual(validateJourneyManifest(manifest), []);
+});
+
+test('native accessibility receipts require both platforms and every journey', () => {
+  const receipt = receiptTemplate(manifest, '1234567');
+  receipt.runs.pop();
+  receipt.runs[0].results['overlay-focus'] = { status: 'pending', evidence: '' };
+  const errors = validateNativeReceipt(receipt, manifest);
+  assert.ok(errors.some((error) => error.includes('exactly one android run')));
+  assert.ok(errors.some((error) => error.includes('ios/overlay-focus needs pass or fail')));
+  assert.ok(errors.some((error) => error.includes('ios/overlay-focus needs linked or local evidence')));
+});
+
+test('a complete passing native accessibility receipt is accepted', () => {
+  const receipt = receiptTemplate(manifest, '1234567');
+  for (const run of receipt.runs) {
+    Object.assign(run, {
+      osVersion: 'current',
+      device: 'release device',
+      build: 'release candidate',
+      tester: 'tester',
+    });
+    for (const result of Object.values(run.results)) {
+      Object.assign(result, { status: 'pass', evidence: `artifacts/${run.platform}.mp4` });
+    }
+  }
+  assert.deepEqual(validateNativeReceipt(receipt, manifest), []);
+});


### PR DESCRIPTION
## Summary

- define seven bounded cross-component native accessibility journeys for iOS/VoiceOver and Android/TalkBack
- add a local receipt generator and validator requiring exact release SHA, device/build/tester metadata, pass/fail, and evidence for every journey on both platforms
- make the native journey contract part of `npm run test:a11y` and document the release workflow
- ignore local accessibility receipts so device evidence cannot be committed accidentally

## Motivation

The deterministic accessibility gate and browser smoke were strong, but recurring residual risk remained unowned at the native gesture and assistive-technology boundary. The manual checklist did not enforce that every release covered controlled rejection, gesture seams, overlay focus, large text, swipe dismissal, structured visuals, and custom screen-reader actions on both mobile platforms.

## Verification

- native journey and gate tests (6/6)
- `npm run test:a11y` (57/57)
- `npm test` (416/416)
- `npm run typecheck`
- `npm run build` (197 source files)
- template generation smoke
- `git diff --check`

## Risk

No component runtime behavior changes. The receipt validates completeness and failed outcomes, but deliberately does not claim to automate VoiceOver/TalkBack or prove that typed evidence is truthful; the named tester remains the release authority. Receipts and device artifacts stay local/linked and are ignored by Git.
