### PR TITLE
docs(state): publish lifecycle matrices

### DIFF
--- a/apps/docs/content/docs/charts/live-line-chart.mdx
+++ b/apps/docs/content/docs/charts/live-line-chart.mdx
@@ -252,6 +252,22 @@ const [held, setHeld] = useState(false);
 </Frame>
 ```
 
+## Lifecycle contract
+
+| Case | Contract |
+| --- | --- |
+| default initialization | An empty input starts with a finite empty domain and no active reading. |
+| controlled acceptance | The data prop is authoritative; normalized finite readings are rendered. |
+| controlled rejection | Not applicable: the chart emits no data mutation requests. |
+| external reset | Replacing data reconciles or clears the selected timestamp. |
+| disabled path | paused and inactive AppState both stop frame ownership. |
+| prop replacement | data, maxPoints, window, motion, pause, and tooltip changes are reconciled. |
+| unmount cleanup | Animation frames and AppState listeners are released; Tooltip removal clears selection. |
+| reduced motion | The live clock owns no frames while reduced motion is active. |
+| callback counts | Selection callbacks follow only accepted finite readings. |
+
+Executable evidence: `packages/panelui/test/live-line-lifecycle.test.mjs` (4 tests).
+
 ## API Reference
 
 ### LiveLineChart

--- a/apps/docs/content/docs/components/carousel.mdx
+++ b/apps/docs/content/docs/components/carousel.mdx
@@ -242,6 +242,22 @@ const [index, setIndex] = useState(0);
 <Button onPress={() => carousel.current?.next()}>Skip</Button>
 ```
 
+## Lifecycle contract
+
+| Case | Contract |
+| --- | --- |
+| default initialization | defaultIndex owns the initial uncontrolled request until the child count is known. |
+| controlled acceptance | A requested index renders only after the owner supplies it. |
+| controlled rejection | A rejected request returns to the accepted prop without restarting its spring. |
+| external reset | A new owner index renders without being reported as a user request. |
+| disabled path | scrollEnabled disables gestures; imperative and explicit controls remain available. |
+| prop replacement | Count, loop, interval, and index changes normalize and re-arm from accepted state. |
+| unmount cleanup | Autoplay owns one timeout and its effect cleanup cancels it. |
+| reduced motion | Accepted movement writes progress immediately instead of starting a spring. |
+| callback counts | Invalid controlled corrections report once per request/count/loop identity. |
+
+Executable evidence: `packages/panelui/test/carousel-lifecycle.test.mjs` (4 tests).
+
 ## API Reference
 
 ### Carousel

--- a/apps/docs/content/docs/components/planner.mdx
+++ b/apps/docs/content/docs/components/planner.mdx
@@ -211,6 +211,22 @@ For a planner inside a sheet, a dialog or a card that already draws its own boun
 </Planner>
 ```
 
+## Lifecycle contract
+
+| Case | Contract |
+| --- | --- |
+| default initialization | defaultMonth and defaultSelected initialize their uncontrolled owners once. |
+| controlled acceptance | Month and selection requests render after their owner supplies them. |
+| controlled rejection | Rejected requests leave the accepted month and selection visible. |
+| external reset | Owner month, selection, and null resets render without request callbacks. |
+| disabled path | Not applicable: Planner has no root disabled contract; consumers disable actions individually. |
+| prop replacement | Equivalent Date instances retain semantic month identity; distinct instants replace it. |
+| unmount cleanup | Lifecycle hooks retain no timers or subscriptions; today refresh owns separate cleanup. |
+| reduced motion | Not applicable: lifecycle state commits do not animate. |
+| callback counts | Each normalized request reports once; prop acceptance and reset report zero times. |
+
+Executable evidence: `packages/panelui/test/planner-lifecycle.test.mjs` (5 tests).
+
 ## Variants
 
 ### `inMonth`

--- a/apps/docs/content/docs/components/toast.mdx
+++ b/apps/docs/content/docs/components/toast.mdx
@@ -119,6 +119,22 @@ toast({
 });
 ```
 
+## Lifecycle contract
+
+| Case | Contract |
+| --- | --- |
+| default initialization | A toast begins with its complete visible-time duration. |
+| controlled acceptance | Not applicable: the toast store owns entries rather than accepting a value prop. |
+| controlled rejection | Not applicable: dismiss requests mutate the owning store directly. |
+| external reset | Clearing or replacing the viewport does not spend background time. |
+| disabled path | Inactive AppState and an unmounted viewport pause every countdown. |
+| prop replacement | Duration is captured per toast; viewport lifecycle changes preserve remaining time. |
+| unmount cleanup | Viewport release pauses timers and removes AppState ownership. |
+| reduced motion | Not applicable to countdown ownership; visual transitions own motion separately. |
+| callback counts | Each timer fires dismissal once after its complete foreground-visible duration. |
+
+Executable evidence: `packages/panelui/test/toast-timer-lifecycle.test.mjs` (3 tests).
+
 ## Variants
 
 ### `variant`

--- a/apps/docs/scripts/gen.mjs
+++ b/apps/docs/scripts/gen.mjs
@@ -2,14 +2,19 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { loadUsage } from './load-usage.mjs';
+import { LIFECYCLE_CASES, loadLifecycleMatrices } from '../../../scripts/lifecycle-matrices.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 /** Repo root, three levels up from apps/docs/scripts. */
 const ROOT = path.resolve(HERE, '../../..');
+const lifecycleMatrices = loadLifecycleMatrices(ROOT);
 
 const S = HERE;
 const api = JSON.parse(fs.readFileSync(`${S}/api.json`, 'utf8'));
 const meta = JSON.parse(fs.readFileSync(`${S}/meta.json`, 'utf8'));
+for (const slug of Object.keys(lifecycleMatrices)) {
+  if (!meta[slug]) throw new Error(`lifecycle matrix has no component metadata: ${slug}`);
+}
 const usage = loadUsage(path.join(S, 'usage'), Object.keys(meta));
 const contentDir = path.join(HERE, '../content/docs');
 
@@ -174,6 +179,7 @@ for (const [slug, entry] of Object.entries(meta)) {
   const c = api[slug];
   if (!c) { console.error('missing api for', slug); continue; }
   const u = usage[slug] ?? {};
+  const lifecycle = lifecycleMatrices[slug];
 
   const parts = c.parts.length ? c.parts.map((p) => `${name}.${p}`) : [];
   // A single string here would spread character by character (`"useState"` →
@@ -296,6 +302,19 @@ ${u.versions.map((v) => [
   demoMedia(v),
   `\n\n\`\`\`tsx\n${v.code}\n\`\`\``,
 ].join('')).join('\n\n')}`);
+  }
+
+  if (lifecycle) {
+    const evidence = lifecycle.evidence
+      .map((item) => `${inlineCode(item.file)} (${item.tests.length} tests)`)
+      .join(', ');
+    sections.push(`## Lifecycle contract
+
+| Case | Contract |
+| --- | --- |
+${LIFECYCLE_CASES.map((key) => `| ${key} | ${esc(lifecycle.cases[key])} |`).join('\n')}
+
+Executable evidence: ${evidence}.`);
   }
 
   /*

--- a/lifecycle-matrices.json
+++ b/lifecycle-matrices.json
@@ -1,0 +1,58 @@
+{
+  "carousel": {
+    "evidence": [{ "file": "packages/panelui/test/carousel-lifecycle.test.mjs", "tests": ["indices clamp or wrap consistently when the slide count shrinks", "an invalid controlled index is rendered safely and reported once", "autoplay stops at the terminal index and re-arms after lifecycle changes", "a move already under way is not re-animated when it echoes back"] }],
+    "cases": {
+      "default initialization": "defaultIndex owns the initial uncontrolled request until the child count is known.",
+      "controlled acceptance": "A requested index renders only after the owner supplies it.",
+      "controlled rejection": "A rejected request returns to the accepted prop without restarting its spring.",
+      "external reset": "A new owner index renders without being reported as a user request.",
+      "disabled path": "scrollEnabled disables gestures; imperative and explicit controls remain available.",
+      "prop replacement": "Count, loop, interval, and index changes normalize and re-arm from accepted state.",
+      "unmount cleanup": "Autoplay owns one timeout and its effect cleanup cancels it.",
+      "reduced motion": "Accepted movement writes progress immediately instead of starting a spring.",
+      "callback counts": "Invalid controlled corrections report once per request/count/loop identity."
+    }
+  },
+  "planner": {
+    "evidence": [{ "file": "packages/panelui/test/planner-lifecycle.test.mjs", "tests": ["a controlled month changes only after its parent accepts the request", "an equivalent controlled Date preserves the settled month identity", "an uncontrolled month commits locally and reports one normalized request", "controlled selection supports rejected requests and external resets", "uncontrolled selection commits child updates including close"] }],
+    "cases": {
+      "default initialization": "defaultMonth and defaultSelected initialize their uncontrolled owners once.",
+      "controlled acceptance": "Month and selection requests render after their owner supplies them.",
+      "controlled rejection": "Rejected requests leave the accepted month and selection visible.",
+      "external reset": "Owner month, selection, and null resets render without request callbacks.",
+      "disabled path": "Not applicable: Planner has no root disabled contract; consumers disable actions individually.",
+      "prop replacement": "Equivalent Date instances retain semantic month identity; distinct instants replace it.",
+      "unmount cleanup": "Lifecycle hooks retain no timers or subscriptions; today refresh owns separate cleanup.",
+      "reduced motion": "Not applicable: lifecycle state commits do not animate.",
+      "callback counts": "Each normalized request reports once; prop acceptance and reset report zero times."
+    }
+  },
+  "live-line-chart": {
+    "evidence": [{ "file": "packages/panelui/test/live-line-lifecycle.test.mjs", "tests": ["the bounded buffer orders, repairs, filters, and trims controlled data", "controlled replacement and maxPoints shrink reconcile the active reading", "the clock only owns frames while foregrounded and visibly live", "runtime cleans up app and tooltip lifecycle ownership"] }],
+    "cases": {
+      "default initialization": "An empty input starts with a finite empty domain and no active reading.",
+      "controlled acceptance": "The data prop is authoritative; normalized finite readings are rendered.",
+      "controlled rejection": "Not applicable: the chart emits no data mutation requests.",
+      "external reset": "Replacing data reconciles or clears the selected timestamp.",
+      "disabled path": "paused and inactive AppState both stop frame ownership.",
+      "prop replacement": "data, maxPoints, window, motion, pause, and tooltip changes are reconciled.",
+      "unmount cleanup": "Animation frames and AppState listeners are released; Tooltip removal clears selection.",
+      "reduced motion": "The live clock owns no frames while reduced motion is active.",
+      "callback counts": "Selection callbacks follow only accepted finite readings."
+    }
+  },
+  "toast": {
+    "evidence": [{ "file": "packages/panelui/test/toast-timer-lifecycle.test.mjs", "tests": ["toast durations exclude time spent with timers paused", "toasts created while paused wait for the viewport to resume", "ToastViewport connects the timer lifecycle to AppState"] }],
+    "cases": {
+      "default initialization": "A toast begins with its complete visible-time duration.",
+      "controlled acceptance": "Not applicable: the toast store owns entries rather than accepting a value prop.",
+      "controlled rejection": "Not applicable: dismiss requests mutate the owning store directly.",
+      "external reset": "Clearing or replacing the viewport does not spend background time.",
+      "disabled path": "Inactive AppState and an unmounted viewport pause every countdown.",
+      "prop replacement": "Duration is captured per toast; viewport lifecycle changes preserve remaining time.",
+      "unmount cleanup": "Viewport release pauses timers and removes AppState ownership.",
+      "reduced motion": "Not applicable to countdown ownership; visual transitions own motion separately.",
+      "callback counts": "Each timer fires dismissal once after its complete foreground-visible duration."
+    }
+  }
+}

--- a/scripts/lifecycle-matrices.mjs
+++ b/scripts/lifecycle-matrices.mjs
@@ -1,0 +1,38 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const LIFECYCLE_CASES = [
+  'default initialization', 'controlled acceptance', 'controlled rejection',
+  'external reset', 'disabled path', 'prop replacement', 'unmount cleanup',
+  'reduced motion', 'callback counts',
+];
+
+const testNames = (source) =>
+  new Set([...source.matchAll(/\b(?:test|it)\(\s*(['"`])([^'"`\n]+)\1/g)].map((match) => match[2]));
+
+export function validateLifecycleMatrices(root, matrices) {
+  const errors = [];
+  for (const [slug, matrix] of Object.entries(matrices)) {
+    const keys = Object.keys(matrix.cases ?? {});
+    for (const key of LIFECYCLE_CASES) {
+      if (!String(matrix.cases?.[key] ?? '').trim()) errors.push(`${slug}: missing lifecycle case ${key}`);
+    }
+    for (const key of keys) if (!LIFECYCLE_CASES.includes(key)) errors.push(`${slug}: unknown lifecycle case ${key}`);
+    if (!matrix.evidence?.length) errors.push(`${slug}: missing lifecycle evidence`);
+    for (const item of matrix.evidence ?? []) {
+      const absolute = path.join(root, item.file);
+      if (!fs.existsSync(absolute)) { errors.push(`${slug}: missing evidence ${item.file}`); continue; }
+      const names = testNames(fs.readFileSync(absolute, 'utf8'));
+      for (const title of item.tests ?? []) if (!names.has(title)) errors.push(`${slug}: missing evidence test ${title}`);
+    }
+  }
+  return errors;
+}
+
+export function loadLifecycleMatrices(root) {
+  const file = path.join(root, 'lifecycle-matrices.json');
+  const matrices = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const errors = validateLifecycleMatrices(root, matrices);
+  if (errors.length) throw new Error(errors.join('\n'));
+  return matrices;
+}

--- a/test/lifecycle-matrices.test.mjs
+++ b/test/lifecycle-matrices.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { LIFECYCLE_CASES, loadLifecycleMatrices, validateLifecycleMatrices } from '../scripts/lifecycle-matrices.mjs';
+
+const root = path.resolve(import.meta.dirname, '..');
+const matrices = loadLifecycleMatrices(root);
+
+test('stateful component lifecycle matrices cover every required case with executable evidence', () => {
+  assert.deepEqual(Object.keys(matrices).sort(), ['carousel', 'live-line-chart', 'planner', 'toast']);
+  for (const matrix of Object.values(matrices)) assert.deepEqual(Object.keys(matrix.cases), LIFECYCLE_CASES);
+  assert.deepEqual(validateLifecycleMatrices(root, matrices), []);
+});
+
+test('lifecycle validation rejects missing cases, files, and test titles together', () => {
+  const broken = structuredClone(matrices);
+  delete broken.carousel.cases['controlled rejection'];
+  broken.planner.evidence[0].file = 'missing.test.mjs';
+  broken.toast.evidence[0].tests[0] = 'renamed test';
+  assert.deepEqual(validateLifecycleMatrices(root, broken), [
+    'carousel: missing lifecycle case controlled rejection',
+    'planner: missing evidence missing.test.mjs',
+    'toast: missing evidence test renamed test',
+  ]);
+});
+
+test('generated pages publish the validated lifecycle matrices', () => {
+  for (const slug of Object.keys(matrices)) {
+    const group = slug === 'live-line-chart' ? 'charts' : 'components';
+    const page = fs.readFileSync(path.join(root, `apps/docs/content/docs/${group}/${slug}.mdx`), 'utf8');
+    assert.match(page, /## Lifecycle contract/);
+    for (const name of LIFECYCLE_CASES) assert.ok(page.includes(`| ${name} |`), `${slug}: ${name}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add reviewable lifecycle matrices for Carousel, Planner, LiveLineChart, and Toast
- require nine explicit cases: initialization, controlled acceptance/rejection, external reset, disabled, prop replacement, cleanup, reduced motion, and callback counts
- validate every matrix against exact executable test titles before docs generation
- render the validated contracts on generated component/chart pages

## Why
Stateful pages documented props but not ownership over time. That let controlled rejection, external resets, cleanup, and callback multiplicity remain implicit even when tests existed. The new manifest makes those contracts reviewable and generator-enforced rather than prose scattered across implementations.

## Verification
- lifecycle matrix contracts: 3/3
- full repository suite: 416/416
- docs typecheck: pass
- docs generation: pass and clean on rerun
- `git diff --check`: pass

## Local build note
The production docs build reached Next/Turbopack but the temporary low-disk worktree intentionally reuses dependencies through an out-of-tree symlink, which Next 16.3 rejects as outside its filesystem root. CI uses a normal `npm ci` tree and remains the authoritative production build for this docs-only change.
