### PR TITLE
perf(components): add scale attribution gates

### DIFF
--- a/apps/docs/content/docs/performance.mdx
+++ b/apps/docs/content/docs/performance.mdx
@@ -139,3 +139,22 @@ useEffect(() => {
   the specific load of a token-by-token AI response.
 - [ScrollFade](/docs/components/scroll-fade) — the zero-re-render scroll
   pattern, with the caveat it imposes on your own `onScroll`.
+
+## Component scale budgets
+
+Aggregate package and example ceilings tell you that the repository grew, not
+which component caused it. The component scale gate reports the owner,
+representative workload, measured operation or mount count, budget, and
+remaining headroom:
+
+```bash
+npm run benchmark:components --workspace=panelui-native
+```
+
+The current reviewed workloads are: a pathological small-content Marquee in a
+390-point viewport; **40 compound Timeline items** (use a bounded data/list path
+for longer histories); BarChart at 500 rows by four stacked series;
+MessageScroller's initial, batch, and viewport windows; and TimePicker's
+1,440-value ruler. These are local contracts rather than claims about device
+frame time. Profile release builds for CPU/layout cost, and add a row when a
+component introduces multiplicative rendering or advertises large-data use.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "template": "node scripts/template-preview.mjs",
     "template:parity": "node scripts/template-parity.mjs",
     "performance:example": "node scripts/verify-example-export.mjs",
-    "performance:check": "npm run verify:package --workspace=panelui-native && npm run benchmark:planner --workspace=panelui-native && node scripts/verify-registry-budgets.mjs"
+    "performance:check": "npm run verify:package --workspace=panelui-native && npm run benchmark:planner --workspace=panelui-native && npm run benchmark:components --workspace=panelui-native && node scripts/verify-registry-budgets.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/packages/panelui/package.json
+++ b/packages/panelui/package.json
@@ -90,7 +90,8 @@
     "clean": "rm -rf lib",
     "verify:package": "node scripts/verify-package.mjs",
     "generate:subpaths": "node scripts/generate-subpath-exports.mjs --write",
-    "check:subpaths": "node scripts/generate-subpath-exports.mjs"
+    "check:subpaths": "node scripts/generate-subpath-exports.mjs",
+    "benchmark:components": "node --experimental-strip-types scripts/benchmark-component-scale.mjs"
   },
   "keywords": [
     "react-native",

--- a/packages/panelui/scripts/benchmark-component-scale.mjs
+++ b/packages/panelui/scripts/benchmark-component-scale.mjs
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { marqueeCopyCount } from '../src/components/marquee/marquee-math.ts';
+import { RULER_WINDOW_SIZE, rulerWindow } from '../src/components/time-picker/ruler-window.ts';
+import { BAR_CHART_BUDGET, barChartOperationCounts } from './benchmark-bar-chart.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+export const COMPONENT_SCALE_BUDGETS = Object.freeze({
+  marqueeCopies: 40,
+  timelineCompoundItems: 40,
+  barChartUpdateVisits: 5_000,
+  barChartFrameVisits: 4_000,
+  messageInitialRows: 12,
+  messageBatchRows: 8,
+  messageWindowScreens: 7,
+  timePickerTicks: RULER_WINDOW_SIZE,
+});
+
+export const timelineCompoundMounts = (items) => Math.max(0, Math.floor(items));
+
+const numberFrom = (source, pattern, label) => {
+  const match = source.match(pattern);
+  if (!match) throw new Error(`Missing component scale contract: ${label}`);
+  return Number(match[1]);
+};
+
+export function componentScaleReport({ root = ROOT, budgets = COMPONENT_SCALE_BUDGETS } = {}) {
+  const message = fs.readFileSync(path.join(root, 'packages/panelui/src/components/message-scroller/index.tsx'), 'utf8');
+  const timeline = fs.readFileSync(path.join(root, 'packages/panelui/src/components/timeline/index.tsx'), 'utf8');
+  if (!/<AnimatedScrollView[\s\S]*\{textChildren\(children\)\}/.test(timeline)) {
+    throw new Error('Missing component scale contract: Timeline compound mount model');
+  }
+  const marquee = marqueeCopyCount(390, 12, 0);
+  const bar = barChartOperationCounts(
+    BAR_CHART_BUDGET.recommended.points,
+    BAR_CHART_BUDGET.recommended.series,
+    true
+  );
+  const ruler = rulerWindow(1_440, 720);
+  const rows = [
+    ['Marquee repeated subtrees', '390pt / 12pt content', marquee.count, budgets.marqueeCopies],
+    ['Timeline compound items', '40-event short horizontal history', timelineCompoundMounts(40), budgets.timelineCompoundItems],
+    ['BarChart update visits', '500 rows × 4 stacked series', bar.updateVisits, budgets.barChartUpdateVisits],
+    ['BarChart frame visits', '500 rows × 4 series', bar.frameVisits, budgets.barChartFrameVisits],
+    ['MessageScroller initial rows', 'virtualized transcript', numberFrom(message, /initialNumToRender = (\d+)/, 'MessageScroller initial rows'), budgets.messageInitialRows],
+    ['MessageScroller batch rows', 'virtualized transcript', numberFrom(message, /maxToRenderPerBatch = (\d+)/, 'MessageScroller batch rows'), budgets.messageBatchRows],
+    ['MessageScroller window screens', 'virtualized transcript', numberFrom(message, /windowSize = (\d+)/, 'MessageScroller window screens'), budgets.messageWindowScreens],
+    ['TimePicker mounted ticks', '1-minute ruler / 1,440 values', ruler.end - ruler.start, budgets.timePickerTicks],
+  ].map(([component, workload, measured, budget]) => ({ component, workload, measured, budget }));
+  return rows;
+}
+
+export function formatComponentScaleReport(rows) {
+  return [
+    'component\tworkload\tmeasured\tbudget\theadroom',
+    ...rows.map((row) => `${row.component}\t${row.workload}\t${row.measured}\t${row.budget}\t${row.budget - row.measured}`),
+  ].join('\n');
+}
+
+function main() {
+  const rows = componentScaleReport();
+  console.log(formatComponentScaleReport(rows));
+  const failures = rows.filter((row) => row.measured > row.budget);
+  if (failures.length) {
+    throw new Error(failures.map((row) => `${row.component}: ${row.measured} > ${row.budget}`).join('\n'));
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) main();

--- a/packages/panelui/test/component-scale-budget.test.mjs
+++ b/packages/panelui/test/component-scale-budget.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import {
+  COMPONENT_SCALE_BUDGETS,
+  componentScaleReport,
+  formatComponentScaleReport,
+} from '../scripts/benchmark-component-scale.mjs';
+
+test('component scale attribution is deterministic and within every local budget', () => {
+  const first = componentScaleReport();
+  const second = componentScaleReport();
+  assert.deepEqual(first, second);
+  assert.equal(first.length, 8);
+  for (const row of first) assert.ok(row.measured <= row.budget, row.component);
+  assert.match(formatComponentScaleReport(first), /component\tworkload\tmeasured\tbudget\theadroom/);
+});
+
+test('component scale attribution identifies each exceeded owner together', () => {
+  const budgets = Object.fromEntries(Object.keys(COMPONENT_SCALE_BUDGETS).map((key) => [key, 0]));
+  const failures = componentScaleReport({ budgets }).filter((row) => row.measured > row.budget);
+  assert.deepEqual(failures.map((row) => row.component), [
+    'Marquee repeated subtrees',
+    'Timeline compound items',
+    'BarChart update visits',
+    'BarChart frame visits',
+    'MessageScroller initial rows',
+    'MessageScroller batch rows',
+    'MessageScroller window screens',
+    'TimePicker mounted ticks',
+  ]);
+});
+
+test('the performance gate and guide own the component attribution command', async () => {
+  const rootPackage = await readFile(new URL('../../../package.json', import.meta.url), 'utf8');
+  const packageManifest = await readFile(new URL('../package.json', import.meta.url), 'utf8');
+  const guide = await readFile(new URL('../../../apps/docs/content/docs/performance.mdx', import.meta.url), 'utf8');
+  assert.match(packageManifest, /"benchmark:components": "node --experimental-strip-types scripts\/benchmark-component-scale\.mjs"/);
+  assert.match(rootPackage, /performance:check[^\n]+benchmark:components/);
+  assert.match(guide, /npm run benchmark:components --workspace=panelui-native/);
+  assert.match(guide, /40 compound Timeline items/);
+});


### PR DESCRIPTION
## Summary
- add a deterministic component-level scale gate for Marquee, Timeline, BarChart, MessageScroller, and TimePicker
- report the owning component, representative workload, measured operation/mount count, ceiling, and headroom
- run the new benchmark in the repository performance gate and document how to extend it

## Why
Aggregate package/export budgets show repository growth but not which component introduced multiplicative work. This makes the current reviewed component contracts executable and attributes failures to their owner.

## Verification
- `node --test packages/panelui/test/component-scale-budget.test.mjs` (3/3)
- `npm test` (416/416)
- `npm run typecheck --workspace=panelui-native`
- `npm run build`
- `npm run performance:check`
- `git diff --check`
